### PR TITLE
Set MARKETING_VERSION to closest git tag before building

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+cd /Volumes/workspace/repository/
+pwd
+git fetch --tags
+NEW_VERSION=$(git describe --abbrev=0)
+echo "Setting marketing version to $NEW_VERSION"
+sed -ie "s/\(MARKETING_VERSION = \)[^;]*/\1$NEW_VERSION/" /Volumes/workspace/repository/eduID.xcodeproj/project.pbxproj
+


### PR DESCRIPTION
This will change the entry in project.pbxproj for MARKETING_VERSION to a value matching the closest git tag, before the build in xcode cloud is started. 

See https://developer.apple.com/documentation/xcode/writing-custom-build-scripts