### PR TITLE
Login, enrollment, PIN validation bugfixes

### DIFF
--- a/EduID/Flows/CreateEduID/CreateEduIDCoordinator.swift
+++ b/EduID/Flows/CreateEduID/CreateEduIDCoordinator.swift
@@ -139,8 +139,9 @@ extension CreateEduIDCoordinator: CreateEduIDViewControllerDelegate {
 
     @objc
     func goBack(viewController: UIViewController) {
-        currentScreenType = ScreenType(rawValue: max(0, currentScreenType.rawValue - 1)) ?? .none
         navigationController.popViewController(animated: true)
+        currentScreenType = (navigationController.topViewController as? BaseViewController)?.screenType ??
+            ScreenType(rawValue: max(0, currentScreenType.rawValue - 1)) ?? .none
     }
 }
 

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDEnterPhoneNumberViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDEnterPhoneNumberViewController.swift
@@ -22,7 +22,7 @@ class CreateEduIDEnterPhoneNumberViewController: CreateEduIDBaseViewController, 
         super.init(nibName: nil, bundle: nil)
         viewModel.alertErrorHandlerDelegate = self
         viewModel.phoneNumberReceivedClosure = { [weak self] result in
-            self?.showNextScreen2()
+            self?.goToConfirmSmsScreen()
         }
     }
     
@@ -130,7 +130,7 @@ class CreateEduIDEnterPhoneNumberViewController: CreateEduIDBaseViewController, 
         viewModel.sendPhoneNumber(number: validatedPhoneTextField.textField.text ?? "")
     }
     
-    func showNextScreen2() {
+    func goToConfirmSmsScreen() {
         (delegate as? CreateEduIDViewControllerDelegate)?.createEduIDViewControllerShowNextScreen(viewController: self)
     }
 }

--- a/EduID/Flows/CreateEduID/ViewControllers/PincodeBaseViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/PincodeBaseViewController.swift
@@ -82,6 +82,8 @@ class PincodeBaseViewController: CreateEduIDBaseViewController {
         posterParent.addSubview(posterLabel)
         posterLabel.edges(to: posterParent)
         
+        screenType.configureNavigationItem(item: navigationItem, target: self, action: #selector(dismissInfoScreen))
+        
         // - create the textView
         let textLabelParent = UIView()
         textLabel = UILabel.plainTextLabelPartlyBold(text:L.PinAndBioMetrics.EnterSixDigitCode.localization, partBold: L.PinAndBioMetrics.SixDigitCode.localization)
@@ -133,6 +135,10 @@ class PincodeBaseViewController: CreateEduIDBaseViewController {
         verifyButton.isEnabled = false
         verifyButton.addTarget(self, action: #selector(showNextScreen), for: .touchUpInside)
         
+    }
+    
+    @objc func dismissInfoScreen() {
+        delegate?.goBack(viewController: self)
     }
     
     //MARK: - gesture action resign keyboard focus

--- a/EduID/Flows/Scanning/VerifyScanResultViewController.swift
+++ b/EduID/Flows/Scanning/VerifyScanResultViewController.swift
@@ -165,8 +165,31 @@ class VerifyScanResultViewController: BaseViewController {
                     guard let self else { return }
                     self.updateUIAfterSigningIn()
                 }
+            } else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.presentPinCodeErrorScreen(error as NSError)
+                }
             }
         }
+    }
+    
+    private func presentPinCodeErrorScreen(_ error: NSError?) {
+        let title = (error?.userInfo[NSLocalizedDescriptionKey] as? String) ?? error?.domain ?? L.Generic.RequestError.Title.localization
+        let description = error?.localizedDescription ?? L.Generic.RequestError.Description(args: String(error?.code ?? 0)).localization
+        let alert = UIAlertController(
+            title: title,
+            message: description,
+            preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.Button.Back.localization, style: .default) { _ in
+            alert.dismiss(animated: true)
+        })
+        if error?.code == 303 {
+            // Incorrect PIN
+            alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.Button.Retry.localization, style: .default) { _ in
+                self.presentPinCodeVerifyScreen()
+            })
+        }
+        self.present(alert, animated: true)
     }
     
     private func updateUIAfterSigningIn() {

--- a/EduID/Flows/Scanning/VerifyScanResultViewController.swift
+++ b/EduID/Flows/Scanning/VerifyScanResultViewController.swift
@@ -31,13 +31,31 @@ class VerifyScanResultViewController: BaseViewController {
         super.viewDidAppear(animated)
         screenType.configureNavigationItem(item: navigationItem)
     }
+    
+    private func requestLoginLabel(entityName: String, challengeType: TIQRChallengeType) -> UILabel {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = 16
+    
+        let labelString = L.PinAndBioMetrics.DoYouWantToLogInTo.localization
+        let entityNameWithQuestionMark = "\(entityName)?"
+        
+        let attributedString = NSMutableAttributedString(string: "\(labelString)\n\(entityNameWithQuestionMark)", attributes: [.font: UIFont.sourceSansProSemiBold(size: 24), .foregroundColor: UIColor.primaryColor, .paragraphStyle: paragraphStyle])
+        attributedString.setAttributeTo(part: entityNameWithQuestionMark, attributes: [.foregroundColor: UIColor.charcoalColor, .font: UIFont.sourceSansProSemiBold(size: 32), .paragraphStyle: paragraphStyle])
+        let label = UILabel()
+        label.attributedText = attributedString
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        return label
+    }
+    
+    
     //MARK: - setupUI
     func setupUI() {
         // - top poster label
-        let posterParent = UIView()
-        let posterLabel = UILabel.posterTextLabelBicolor(text: L.PinAndBioMetrics.LoginRequest.localization, primary: L.PinAndBioMetrics.LoginRequest.localization)
-        posterParent.addSubview(posterLabel)
-        posterLabel.edges(to: posterParent)
+        let posterLabel = UILabel.posterTextLabelBicolor(
+            text: L.PinAndBioMetrics.LoginRequest.localization,
+            primary: L.PinAndBioMetrics.LoginRequest.localization
+        )
         
         let upperspace = UIView()
         
@@ -47,9 +65,15 @@ class VerifyScanResultViewController: BaseViewController {
         
         switch viewModel.challengeType {
         case .enrollment:
-            middlePosterLabel = UILabel.requestLoginLabel(entityName: (viewModel.challenge as? EnrollmentChallenge)?.identityDisplayName ?? "", challengeType: viewModel.challengeType ?? .invalid)
+            middlePosterLabel = requestLoginLabel(
+                entityName: (viewModel.challenge as? EnrollmentChallenge)?.identityDisplayName ?? "",
+                challengeType: viewModel.challengeType ?? .invalid
+            )
         case .authentication:
-            middlePosterLabel = UILabel.requestLoginLabel(entityName: (viewModel.challenge as? AuthenticationChallenge)?.serviceProviderDisplayName ?? "", challengeType: viewModel.challengeType ?? .invalid)
+            middlePosterLabel = requestLoginLabel(
+                entityName: (viewModel.challenge as? AuthenticationChallenge)?.serviceProviderDisplayName ?? "", 
+                challengeType: viewModel.challengeType ?? .invalid
+            )
         default:
             break
         }
@@ -76,11 +100,12 @@ class VerifyScanResultViewController: BaseViewController {
         animatedHStack.spacing = 24
         
         // - the stackView
-        mainStack = BasicStackView(arrangedSubviews: [posterParent, upperspace, middlePosterParent, lowerSpace, animatedHStack])
+        mainStack = BasicStackView(arrangedSubviews: [posterLabel, upperspace, middlePosterParent, lowerSpace, animatedHStack])
         view.addSubview(mainStack)
         
         // - constraints
         mainStack.edgesToSuperview(insets: TinyEdgeInsets(top: 24, left: 24, bottom: 24, right: 24), usingSafeArea: true)
+        posterLabel.width(to: mainStack)
         upperspace.height(to: lowerSpace)
         animatedHStack.width(to: mainStack)
         primaryButton.width(to: cancelButton)

--- a/EduID/Localizable.swift
+++ b/EduID/Localizable.swift
@@ -5383,6 +5383,24 @@ public struct L {
             translationKey: "PinAndBioMetrics.VerifyPin.COPY",
             translationArgs: []
         )
+        public struct Button {
+            public static let Retry = LocaliciousData(
+                accessibilityIdentifier: "PinAndBioMetrics.Button.Retry",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: "PinAndBioMetrics.Button.Retry.COPY",
+                translationArgs: []
+            )
+            public static let Back = LocaliciousData(
+                accessibilityIdentifier: "PinAndBioMetrics.Button.Back",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: "PinAndBioMetrics.Button.Back.COPY",
+                translationArgs: []
+            )
+        }
         public static let CheckMessages = LocaliciousData(
             accessibilityIdentifier: "PinAndBioMetrics.CheckMessages",
             accessibilityHintKey: nil,

--- a/EduID/Localizable.swift
+++ b/EduID/Localizable.swift
@@ -5359,6 +5359,14 @@ public struct L {
             translationKey: "PinAndBioMetrics.LoginRequest.COPY",
             translationArgs: []
         )
+        public static let DoYouWantToLogInTo = LocaliciousData(
+            accessibilityIdentifier: "PinAndBioMetrics.DoYouWantToLogInTo",
+            accessibilityHintKey: nil,
+            accessibilityLabelKey: nil,
+            accessibilityValueKey: nil,
+            translationKey: "PinAndBioMetrics.DoYouWantToLogInTo.COPY",
+            translationArgs: []
+        )
         public static let EnteredPinNotEqual = LocaliciousData(
             accessibilityIdentifier: "PinAndBioMetrics.EnteredPinNotEqual",
             accessibilityHintKey: nil,

--- a/EduID/Resources/General/en.lproj/Localizable.strings
+++ b/EduID/Resources/General/en.lproj/Localizable.strings
@@ -638,6 +638,8 @@ Would you like to deactivate existing enrollment to enroll on this device?
 "PinAndBioMetrics.EnteredPinNotEqual.COPY" = "The entered PIN codes were not equal";
 "PinAndBioMetrics.RetryPin.COPY" = "Oops, let's try again";
 "PinAndBioMetrics.VerifyPin.COPY" = "Verify this pin code";
+"PinAndBioMetrics.Button.Retry.COPY" = "Try again";
+"PinAndBioMetrics.Button.Back.COPY" = "Back";
 "PinAndBioMetrics.CheckMessages.COPY" = "Check your messages";
 "PinAndBioMetrics.EnterSixDigitCode.COPY" = "Enter the six-digit code we sent to your phone to continue";
 "PinAndBioMetrics.SixDigitCode.COPY" = "six-digit";

--- a/EduID/Resources/General/en.lproj/Localizable.strings
+++ b/EduID/Resources/General/en.lproj/Localizable.strings
@@ -634,7 +634,8 @@ Would you like to deactivate existing enrollment to enroll on this device?
 "PinAndBioMetrics.VerifyPinScreenText.COPY" = "Enter the PIN and press OK";
 "PinAndBioMetrics.SignIn.COPY" = "Login";
 "PinAndBioMetrics.OKButton.COPY" = "OK";
-"PinAndBioMetrics.LoginRequest.COPY" = "Request to login";
+"PinAndBioMetrics.LoginRequest.COPY" = "Request to log on";
+"PinAndBioMetrics.DoYouWantToLogInTo.COPY" = "Do you want to log in to";
 "PinAndBioMetrics.EnteredPinNotEqual.COPY" = "The entered PIN codes were not equal";
 "PinAndBioMetrics.RetryPin.COPY" = "Oops, let's try again";
 "PinAndBioMetrics.VerifyPin.COPY" = "Verify this pin code";

--- a/EduID/Resources/General/nl.lproj/Localizable.strings
+++ b/EduID/Resources/General/nl.lproj/Localizable.strings
@@ -635,7 +635,8 @@ Wil je 2FA op het bestaande toestel deactiveren en hier toevoegen?
 "PinAndBioMetrics.VerifyPinScreenText.COPY" = "Voer uw PIN in en druk op OK";
 "PinAndBioMetrics.SignIn.COPY" = "Inloggen";
 "PinAndBioMetrics.OKButton.COPY" = "OK";
-"PinAndBioMetrics.LoginRequest.COPY" = "Inlogverzoek";
+"PinAndBioMetrics.LoginRequest.COPY" = "Verzoek om in te loggen";
+"PinAndBioMetrics.DoYouWantToLogInTo.COPY" = "Wil je inloggen bij";
 "PinAndBioMetrics.EnteredPinNotEqual.COPY" = "De ingevoerde pincodes waren niet gelijk";
 "PinAndBioMetrics.RetryPin.COPY" = "Oeps, laten we het opnieuw proberen";
 "PinAndBioMetrics.VerifyPin.COPY" = "Controleer pincode";

--- a/EduID/Resources/General/nl.lproj/Localizable.strings
+++ b/EduID/Resources/General/nl.lproj/Localizable.strings
@@ -639,6 +639,8 @@ Wil je 2FA op het bestaande toestel deactiveren en hier toevoegen?
 "PinAndBioMetrics.EnteredPinNotEqual.COPY" = "De ingevoerde pincodes waren niet gelijk";
 "PinAndBioMetrics.RetryPin.COPY" = "Oeps, laten we het opnieuw proberen";
 "PinAndBioMetrics.VerifyPin.COPY" = "Controleer pincode";
+"PinAndBioMetrics.Button.Retry.COPY" = "Probeer opnieuw";
+"PinAndBioMetrics.Button.Back.COPY" = "Terug";
 "PinAndBioMetrics.CheckMessages.COPY" = "Controleer je berichten";
 "PinAndBioMetrics.EnterSixDigitCode.COPY" = "Voer de zescijferige code in die we naar je telefoon hebben gestuurd om door te gaan";
 "PinAndBioMetrics.SixDigitCode.COPY" = "zescijferige";

--- a/EduID/Styling/UILabel+Styling.swift
+++ b/EduID/Styling/UILabel+Styling.swift
@@ -53,27 +53,4 @@ extension UILabel {
         label.sizeToFit()
         return label
     }
-    
-    static func requestLoginLabel(entityName: String, challengeType: TIQRChallengeType) -> UILabel {
-        var paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 16
-        
-        var labelString = ""
-        switch challengeType {
-        case .enrollment:
-            labelString = "Request enrollment for user:\n"
-        case .authentication:
-            labelString = "Request login for:\n"
-        default:
-            break
-        }
-        
-        let attributedString = NSMutableAttributedString(string: "\(labelString)\(entityName)", attributes: [.font: UIFont.sourceSansProSemiBold(size: 24), .foregroundColor: UIColor.primaryColor, .paragraphStyle: paragraphStyle])
-        attributedString.setAttributeTo(part: entityName, attributes: [.foregroundColor: UIColor.charcoalColor, .font: UIFont.sourceSansProSemiBold(size: 36), .paragraphStyle: paragraphStyle])
-        let label = UILabel()
-        label.attributedText = attributedString
-        label.numberOfLines = 0
-        label.textAlignment = .center
-        return label
-    }
 }

--- a/EduID/Types/ScreenType.swift
+++ b/EduID/Types/ScreenType.swift
@@ -153,14 +153,16 @@ enum ScreenType: Int, CaseIterable {
             item.hidesBackButton = true
             item.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "xmark"), style: .plain, target: target, action: action)
             item.rightBarButtonItem?.tintColor = .white
-            // just logo
+            
+            // Just logo, no back button
         case .homeScreen, .confirmScreen, .verifyLoginScreen, .createPincodefirstEntryScreen,
                 .createPincodeSecondEntryScreen,.biometricApprovalScreen,
                 .firstTimeDialogScreen, .eduIDCreatedScreen, .registrationCheck,
-                .enterPhoneScreen, .smsChallengeScreen, .addInstitutionScreen, .welcomeScreen, .returnToBrowser:
+                .enterPhoneScreen, .addInstitutionScreen, .welcomeScreen, .returnToBrowser:
             addLogoTo(item: item)
             item.hidesBackButton = true
             
+            // Back button
         default:
             addLogoTo(item: item)
             item.hidesBackButton = true

--- a/EduID/Utilities/Constants.swift
+++ b/EduID/Utilities/Constants.swift
@@ -4,7 +4,7 @@ enum Constants {
     
     enum RegEx {
         static let emailRegex = #"^(?=.{6,})[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"#
-        static let nameRegex = #"^[a-zA-Z]+(?:[a-zA-Z- ']+)*$"#
+        static let nameRegex = #"^(?!\s*$).+"# // Checks for "is-not-empty"
         static let shortPasswordRegex = #"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d\w\W]{8,}$"#
         static let longPasswordRegex = #".{15,}"#
         static let phoneRegex = #"^(?:(?:00|\+)?\d{1,2}\s?)?\(?(?:\d{3}[\s-]?\d{3}[\s-]?\d{4}|\d{10})\)?$"#

--- a/EduID/localizations.yaml
+++ b/EduID/localizations.yaml
@@ -3076,6 +3076,15 @@ IOS:
         COPY:
           en: Verify this pin code
           nl: Controleer pincode
+    Button:
+      Retry:
+        COPY:
+          en: Try again
+          nl: Probeer opnieuw
+      Back:
+        COPY:
+          en: Back
+          nl: Terug
     CheckMessages:
         COPY:
           en: Check your messages

--- a/EduID/localizations.yaml
+++ b/EduID/localizations.yaml
@@ -3062,8 +3062,12 @@ IOS:
         nl: OK
     LoginRequest:
       COPY:
-        en: Request to login
-        nl: Inlogverzoek
+        en: Request to log on
+        nl: Verzoek om in te loggen
+    DoYouWantToLogInTo:
+      COPY:
+        en: Do you want to log in to
+        nl: Wil je inloggen bij
     EnteredPinNotEqual:
       COPY:
         en: The entered PIN codes were not equal


### PR DESCRIPTION
This PR brings a number of improvements (mostly bugfixes) to the eduID app:

TIQR-314: If the entered PIN was incorrect, it was not described correctly to the user
TIQR-353: Login request screen has been corrected to match Figma design
TIQR-352: Enrollment request has been removed, and will be improved more in the next PR
TIQR-364: Removed name validation, it has been changed to  "not empty" (only whitespace is not allowed as well)
TIQR-362: User can now go back from the SMS message entry screen, to correct the phone number, if required