### PR TITLE
TIQR-367: Allow addition of multiple 2FA keys

### DIFF
--- a/EduID/Flows/CreateEduID/CreateEduIDCoordinator.swift
+++ b/EduID/Flows/CreateEduID/CreateEduIDCoordinator.swift
@@ -20,6 +20,11 @@ final class CreateEduIDCoordinator: CoordinatorType {
         self.viewControllerToPresentOn = viewControllerToPresentOn
         NotificationCenter.default.addObserver(self, selector: #selector(startExistingUserWithoutSecretFlow), name: .firstTimeAuthorizationComplete, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(startExistingUserWithSecretFlow), name: .firstTimeAuthorizationCompleteWithSecretPresent, object: nil)
+        let navigationController = UINavigationController()
+        navigationController.isModalInPresentation = true
+        navigationController.modalPresentationStyle = .fullScreen
+        self.navigationController = navigationController
+        viewControllerToPresentOn?.present(self.navigationController, animated: false)
     }
     
     deinit {
@@ -27,15 +32,10 @@ final class CreateEduIDCoordinator: CoordinatorType {
     }
     
     //MARK: - start
-    func start() {
+    func startWithLanding() {
         let landingScreen = CreateEduIDLandingPageViewController()
         landingScreen.delegate = self
-        let navigationController = UINavigationController(rootViewController: landingScreen)
-        navigationController.isModalInPresentation = true
-        navigationController.modalPresentationStyle = .fullScreen
-        self.navigationController = navigationController
-        // the next line is responsible for presenting the onboarding and is sometimes commented out for development purposes
-        viewControllerToPresentOn?.present(self.navigationController, animated: false)
+        navigationController.setViewControllers([landingScreen], animated: false)
     }
     
     @objc func startExistingUserWithoutSecretFlow() {
@@ -61,7 +61,11 @@ extension CreateEduIDCoordinator: ScanCoordinatorDelegate {
             return
         }
         
-        let pincodeFirstAttemptViewController = CreatePincodeFirstEntryViewController(viewModel: CreatePincodeAndBiometricAccessViewModel(enrollmentChallenge: challenge, isQrEnrolment: true))
+        let pincodeFirstAttemptViewController = CreatePincodeFirstEntryViewController(
+            viewModel: CreatePincodeAndBiometricAccessViewModel(
+                enrollmentChallenge: challenge
+            )
+        )
         
         pincodeFirstAttemptViewController.delegate = self
         navigationController.pushViewController(pincodeFirstAttemptViewController, animated: true)
@@ -87,7 +91,7 @@ extension CreateEduIDCoordinator: CreateEduIDViewControllerDelegate {
             return
         }
         
-        // - this is the end of the onboarding in case the user has scannes the enrollment qr from the web
+        // - this is the end of the onboarding in case the user has scanned the enrollment qr from the web
         if let onboardingTypeString = UserDefaults.standard.value(forKey: OnboardingManager.userdefaultsFlowTypeKey) as? String, OnboardingFlowType(rawValue: onboardingTypeString) == .mfaOnly {
             if currentScreenType == .biometricApprovalScreen {
                 

--- a/EduID/Flows/CreateEduID/ViewModels/CreatePincodeAndBiometricAccessViewModel.swift
+++ b/EduID/Flows/CreateEduID/ViewModels/CreatePincodeAndBiometricAccessViewModel.swift
@@ -29,10 +29,9 @@ final class CreatePincodeAndBiometricAccessViewModel: NSObject {
     private let biometricService = BiometricService()
 
     //MARK: - init
-    init(enrollmentChallenge: EnrollmentChallenge? = nil, authenticationChallenge: AuthenticationChallenge? = nil, isQrEnrolment: Bool? = nil) {
+    init(enrollmentChallenge: EnrollmentChallenge? = nil, authenticationChallenge: AuthenticationChallenge? = nil) {
         self.enrollmentChallenge = enrollmentChallenge
         self.authenticationChallenge = authenticationChallenge
-        ScreenType.isQrEnrolment = isQrEnrolment
         super.init()
     }
     

--- a/EduID/Flows/Home/MainCoordinator.swift
+++ b/EduID/Flows/Home/MainCoordinator.swift
@@ -25,7 +25,7 @@ class MainCoordinator: CoordinatorType {
             let onboardingCoordinator = CreateEduIDCoordinator(viewControllerToPresentOn: homeNavigationController)
             children.append(onboardingCoordinator)
             onboardingCoordinator.delegate = self
-            onboardingCoordinator.start()
+            onboardingCoordinator.startWithLanding()
         }
     }
     
@@ -85,7 +85,11 @@ extension MainCoordinator: PersonalInfoCoordinatorDelegate {
 extension MainCoordinator: ScanCoordinatorDelegate {
     
     func scanCoordinatorJumpToCreatePincodeScreen(coordinator: ScanCoordinator, viewModel: ScanViewModel) {
-        // not implemented
+        // Our responsibility stops here, and we delegate to the eduID coordinator, which will continue with the flow
+        homeNavigationController.popToRootViewController(animated: false)
+        let eduidCoordinator = CreateEduIDCoordinator(viewControllerToPresentOn: homeNavigationController)
+        children.append(eduidCoordinator)
+        eduidCoordinator.scanCoordinatorJumpToCreatePincodeScreen(coordinator: coordinator, viewModel: viewModel)
     }
     
     func scanCoordinatorDismissScanScreen(coordinator: ScanCoordinator) {

--- a/EduID/Flows/Scanning/ScanCoordinator.swift
+++ b/EduID/Flows/Scanning/ScanCoordinator.swift
@@ -61,7 +61,11 @@ extension ScanCoordinator: VerifyScanResultViewControllerDelegate {
     }
     
     func verifyScanResultViewControllerLogin(viewController: VerifyScanResultViewController, viewModel: ScanViewModel) {
-        let pincodeFirstEntryViewController = CreatePincodeFirstEntryViewController(viewModel: CreatePincodeAndBiometricAccessViewModel(authenticationChallenge: viewModel.challenge as? AuthenticationChallenge))
+        let pincodeFirstEntryViewController = CreatePincodeFirstEntryViewController(
+            viewModel: CreatePincodeAndBiometricAccessViewModel(
+                authenticationChallenge: viewModel.challenge as? AuthenticationChallenge
+            )
+        )
         navigationController.pushViewController(pincodeFirstEntryViewController, animated: true)
     }
     

--- a/EduID/Flows/Scanning/VerifyScanResultViewController.swift
+++ b/EduID/Flows/Scanning/VerifyScanResultViewController.swift
@@ -65,13 +65,15 @@ class VerifyScanResultViewController: BaseViewController {
         
         switch viewModel.challengeType {
         case .enrollment:
+            let challenge = viewModel.challenge as? EnrollmentChallenge
             middlePosterLabel = requestLoginLabel(
-                entityName: (viewModel.challenge as? EnrollmentChallenge)?.identityDisplayName ?? "",
+                entityName: challenge?.identityProviderDisplayName ?? challenge?.identityDisplayName ?? "",
                 challengeType: viewModel.challengeType ?? .invalid
             )
         case .authentication:
+            let challenge = viewModel.challenge as? AuthenticationChallenge
             middlePosterLabel = requestLoginLabel(
-                entityName: (viewModel.challenge as? AuthenticationChallenge)?.serviceProviderDisplayName ?? "", 
+                entityName: challenge?.serviceProviderDisplayName ?? challenge?.serviceProviderIdentifier ?? "",
                 challengeType: viewModel.challengeType ?? .invalid
             )
         default:

--- a/EduID/Flows/Security/TwoFactorKeys/TwoFactorKeysViewModel.swift
+++ b/EduID/Flows/Security/TwoFactorKeys/TwoFactorKeysViewModel.swift
@@ -31,8 +31,19 @@ class TwoFactorKeysViewModel {
     }
     
     func removeIdentity(identity: Identity) {
-        ServiceContainer.sharedInstance().identityService.delete(identity)
-        ServiceContainer.sharedInstance().identityService.saveIdentities()
+        let identityService = ServiceContainer.sharedInstance().identityService!
+        let identityProvider = identity.identityProvider
+        
+        if identityProvider != nil {
+            identityProvider!.removeIdentitiesObject(identity)
+            identityService.delete(identity)
+            if identityProvider!.identities.count == 0 {
+                identityService.delete(identityProvider)
+            }
+        } else {
+            identityService.delete(identity)
+        }
+        identityService.saveIdentities()
         didRemoveIdentities = true
     }
 }

--- a/EduID/Types/ScreenType.swift
+++ b/EduID/Types/ScreenType.swift
@@ -2,9 +2,6 @@ import UIKit
 
 @objc
 enum ScreenType: Int, CaseIterable {
-    
-    static var isQrEnrolment: Bool?
-    
     // home screen
     case homeScreen
     
@@ -76,9 +73,7 @@ enum ScreenType: Int, CaseIterable {
         case .createPincodeSecondEntryScreen:
             return .biometricApprovalScreen
         case .biometricApprovalScreen:
-            return ScreenType.isQrEnrolment != nil
-            ? .returnToBrowser
-            : .enterPhoneScreen
+            return AppAuthController.shared.isLoggedIn() ? .enterPhoneScreen : .returnToBrowser 
         case .enterPhoneScreen:
             return .smsChallengeScreen
         case .smsChallengeScreen:


### PR DESCRIPTION
The scan coordinator did not understand the enrolment flow, so we now delegate to the createEduID coordinator (instead of duplicating behavior). For this delegation I had to rewrite the startup sequence of the coordinator, so that it can not only start with the landing screen, but any other screen if needed.
I also matched a bit of the flow (when to return to browser and when to ask for phone number) with the Android app.
While testing, I also discovered a bug, that deleting the 2FA key also deleted identity provider (even if there were multiple keys for the same provider). This was due to a CoreData connection. I corrected this by breaking the connection before removal, now it works correctly.