### PR TITLE
TIQR-365: Custom error when authentication failed

### DIFF
--- a/EduID/Flows/Scanning/VerifyScanResultViewController.swift
+++ b/EduID/Flows/Scanning/VerifyScanResultViewController.swift
@@ -201,19 +201,24 @@ class VerifyScanResultViewController: BaseViewController {
     }
     
     private func presentPinCodeErrorScreen(_ error: NSError?) {
-        let title = (error?.userInfo[NSLocalizedDescriptionKey] as? String) ?? error?.domain ?? L.Generic.RequestError.Title.localization
-        let description = error?.localizedDescription ?? L.Generic.RequestError.Description(args: String(error?.code ?? 0)).localization
+        var title = (error?.userInfo[NSLocalizedDescriptionKey] as? String) ?? error?.domain ?? L.Generic.RequestError.Title.localization
+        var description = (error?.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? error?.localizedDescription ?? L.Generic.RequestError.Description(args: String(error?.code ?? 0)).localization
+        if title == "unknown_error" {
+            title = L.ResponseErrors.AuthenticationFailedTitle.localization
+            description = L.ResponseErrors.AuthenticationFailedMessage.localization
+        }
         let alert = UIAlertController(
             title: title,
             message: description,
             preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.Button.Back.localization, style: .default) { _ in
+        alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.Button.Back.localization, style: .default) { [weak self] _ in
             alert.dismiss(animated: true)
+            self?.dismissView()
         })
         if error?.code == 303 {
             // Incorrect PIN
-            alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.Button.Retry.localization, style: .default) { _ in
-                self.presentPinCodeVerifyScreen()
+            alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.Button.Retry.localization, style: .default) { [weak self] _ in
+                self?.presentPinCodeVerifyScreen()
             })
         }
         self.present(alert, animated: true)

--- a/EduID/Localizable.swift
+++ b/EduID/Localizable.swift
@@ -5851,6 +5851,22 @@ public struct L {
         )
     }
     public struct ResponseErrors {
+        public static let AuthenticationFailedTitle = LocaliciousData(
+            accessibilityIdentifier: "ResponseErrors.AuthenticationFailedTitle",
+            accessibilityHintKey: nil,
+            accessibilityLabelKey: nil,
+            accessibilityValueKey: nil,
+            translationKey: "ResponseErrors.AuthenticationFailedTitle.COPY",
+            translationArgs: []
+        )
+        public static let AuthenticationFailedMessage = LocaliciousData(
+            accessibilityIdentifier: "ResponseErrors.AuthenticationFailedMessage",
+            accessibilityHintKey: nil,
+            accessibilityLabelKey: nil,
+            accessibilityValueKey: nil,
+            translationKey: "ResponseErrors.AuthenticationFailedMessage.COPY",
+            translationArgs: []
+        )
         public static let UnauthorizedTitle = LocaliciousData(
             accessibilityIdentifier: "ResponseErrors.UnauthorizedTitle",
             accessibilityHintKey: nil,

--- a/EduID/Resources/General/en.lproj/Localizable.strings
+++ b/EduID/Resources/General/en.lproj/Localizable.strings
@@ -705,6 +705,8 @@ We will text you a code to verify your number.
 "RegEXError.Email.COPY" = "Invalid email format, please revise your input";
 "RegEXError.Phone.COPY" = "Invalid phone format, please revise your input";
 "RegEXError.Password.COPY" = "Password is too weak";
+"ResponseErrors.AuthenticationFailedTitle.COPY" = "Authentication Failed";
+"ResponseErrors.AuthenticationFailedMessage.COPY" = "Try again in a moment.";
 "ResponseErrors.UnauthorizedTitle.COPY" = "Cannot load data";
 "ResponseErrors.UnauthorizedText.COPY" = "Cannot complete request, please sign in and grant access.";
 "ResponseErrors.EmailInUseTitle.COPY" = "E-mail already in use";

--- a/EduID/Resources/General/nl.lproj/Localizable.strings
+++ b/EduID/Resources/General/nl.lproj/Localizable.strings
@@ -706,6 +706,8 @@ We sturen je een code om je nummer te verifiëren.
 "RegEXError.Email.COPY" = "Ongeldig e-mailformaat, pas je invoer aan";
 "RegEXError.Phone.COPY" = "Ongeldig telefoonnummer, pas je invoer aan";
 "RegEXError.Password.COPY" = "Wachtwoord niet sterk genoeg";
+"ResponseErrors.AuthenticationFailedTitle.COPY" = "Inloggen mislukt";
+"ResponseErrors.AuthenticationFailedMessage.COPY" = "Probeer het over een ogenblik opnieuw.";
 "ResponseErrors.UnauthorizedTitle.COPY" = "Gegevens kunnen niet laden";
 "ResponseErrors.UnauthorizedText.COPY" = "Verzoek kan niet worden voltooid, log in en geef toegang";
 "ResponseErrors.EmailInUseTitle.COPY" = "E-mail al in gebruik";

--- a/EduID/localizations.yaml
+++ b/EduID/localizations.yaml
@@ -3357,6 +3357,14 @@ IOS:
         en: Password is too weak
         nl: Wachtwoord niet sterk genoeg
   ResponseErrors:
+    AuthenticationFailedTitle:
+      COPY:
+        en: Authentication Failed
+        nl: Inloggen mislukt
+    AuthenticationFailedMessage:
+      COPY:
+        en: Try again in a moment.
+        nl: Probeer het over een ogenblik opnieuw.
     UnauthorizedTitle:
       COPY:
         en: Cannot load data


### PR DESCRIPTION
The `test.eduid.nl` seems to have and older (or modified?) Tiqr version running, which returns an `unknown_error` on an incorrect PIN. We detect this in the app, and instead of displaying the raw error code, we show a proper message.