### PR TITLE
TIQR-375: Remove debugPrint, fix bundle ID for debug builds

### DIFF
--- a/EduID/Flows/Scanning/VerifyScanResultViewController.swift
+++ b/EduID/Flows/Scanning/VerifyScanResultViewController.swift
@@ -190,7 +190,6 @@ class VerifyScanResultViewController: BaseViewController {
             return
         }
         ServiceContainer.sharedInstance().challengeService.complete(challenge, withSecret: secret) { success, response, error in
-            debugPrint("Success: \(success), response: \(response), error: \(error)")
             if success {
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }

--- a/eduID.xcodeproj/project.pbxproj
+++ b/eduID.xcodeproj/project.pbxproj
@@ -1824,7 +1824,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 2.0;
-				PRODUCT_BUNDLE_IDENTIFIER = nl.eduid.testing;
+				PRODUCT_BUNDLE_IDENTIFIER = nl.eduid;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/eduID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/eduID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -30,7 +30,7 @@
     {
       "identity" : "sdwebimage",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SDWebImage/SDWebImage.git",
+      "location" : "https://github.com/SDWebImage/SDWebImage",
       "state" : {
         "revision" : "c51ba84499268ea3020e6aee9e229c0f56b9d924",
         "version" : "5.16.0"


### PR DESCRIPTION
The debugPrint crashed the app when error was nil.

Also the bundle ID should be only .testing if it is the testing scheme.