### PR TITLE
TIQR-386: Fix info not always having the commit hashes

### DIFF
--- a/EduID/Flows/EnvironmentSwitcher/EnvironmentSwitcherController.swift
+++ b/EduID/Flows/EnvironmentSwitcher/EnvironmentSwitcherController.swift
@@ -54,7 +54,7 @@ class EnvironmentSwitcherController: UIViewController {
         stack.axis = .vertical
         stack.spacing = 16
         insetView.addSubview(stack)
-        stack.edgesToSuperview(insets: .uniform(20))
+        stack.edgesToSuperview(insets: .uniform(20), usingSafeArea: true)
         EnvironmentService.shared.environments.enumerated().forEach { (index, environment) in
             let isCurrent = EnvironmentService.shared.currentEnvironment.name == environment.name
             let button = EduIDButton(type: .ghost, buttonTitle: environment.name)

--- a/EduID/Flows/Home/InfoViewController.swift
+++ b/EduID/Flows/Home/InfoViewController.swift
@@ -7,6 +7,7 @@
 import Foundation
 import UIKit
 import TinyConstraints
+import TiqrCoreObjC
 
 class InfoViewController: UIViewController {
     
@@ -49,22 +50,14 @@ class InfoViewController: UIViewController {
         let appName = Bundle.main.infoDictionary?[kCFBundleNameKey as String] as? String ?? "eduID"
         let appVersionName = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0"
         let appVersionCode = Bundle.main.infoDictionary?[kCFBundleVersionKey as String] as? String ?? "0"
-        var tiqrReleaseVersion = (Bundle.main.infoDictionary?["TIQRGitReleaseVersion"] as? String)
-        if let longVersion = tiqrReleaseVersion,
-           longVersion.count > 7 {
-            tiqrReleaseVersion = String(longVersion[longVersion.startIndex..<longVersion.index(longVersion.startIndex, offsetBy: 7)])
-        }
-        var tiqrLibraryVersion = (Bundle.main.infoDictionary?["TIQRLibraryVersion"] as? String)
-        if let longVersion=tiqrLibraryVersion,
-           longVersion.count > 7 {
-            tiqrLibraryVersion = String(longVersion[longVersion.startIndex..<longVersion.index(longVersion.startIndex, offsetBy: 7)])
-        }
 #if DEBUG
         let debugString = "DEBUG"
 #else
         let debugString = ""
 #endif
-        let versionText = "\(appName) • v\(appVersionName) (\(appVersionCode)) • \(tiqrReleaseVersion ?? "<unknown>")-\(tiqrLibraryVersion ?? "<unknown>") \(debugString)"
+        let tiqrReleaseVersion = TiqrConfig.shortGitReleaseVersion
+        let tiqrLibraryVersion = TiqrConfig.shortCoreLibraryVersion
+        let versionText = "\(appName) • v\(appVersionName) (\(appVersionCode)) • \(tiqrReleaseVersion ?? "<unknown>") - core \(tiqrLibraryVersion ?? "<unknown>") \(debugString)"
         let eduidVersion = UILabel.plainTextLabelPartlyBold(text: versionText)
         eduidVersion.textAlignment = .center
         let eduidLogo = UIImageView()
@@ -85,7 +78,7 @@ class InfoViewController: UIViewController {
         stack.axis = .vertical
         stack.spacing = 16
         insetView.addSubview(stack)
-        stack.edgesToSuperview(insets: .uniform(20))
+        stack.edgesToSuperview(insets: .uniform(20), usingSafeArea: true)
         
         eduidVersion.widthToSuperview()
         eduidLogo.widthToSuperview()

--- a/eduID.xcodeproj/project.pbxproj
+++ b/eduID.xcodeproj/project.pbxproj
@@ -1280,8 +1280,8 @@
 				0AFD9DFD2745579900D48C01 /* Sources */,
 				0AFD9DFE2745579900D48C01 /* Frameworks */,
 				0AFD9DFF2745579900D48C01 /* Resources */,
-				C773FF2529263B2400A82451 /* Set Git Release and Library Version */,
 				4FF568032A31D60300616341 /* Embed Frameworks */,
+				C773FF2529263B2400A82451 /* Set Git Release and Library Version */,
 			);
 			buildRules = (
 			);
@@ -2499,7 +2499,7 @@
 			repositoryURL = "https://github.com/Tiqr/tiqr-app-core-ios";
 			requirement = {
 				kind = revision;
-				revision = c04b19c21426c9b48ea5fc9888925e2b6ef417aa;
+				revision = 5c10fb44d312ff91865c030f044984e9ee495e8a;
 			};
 		};
 		4FF567D92A31D3FA00616341 /* XCRemoteSwiftPackageReference "TinyConstraints" */ = {

--- a/eduID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/eduID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,7 +50,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Tiqr/tiqr-app-core-ios",
       "state" : {
-        "revision" : "c04b19c21426c9b48ea5fc9888925e2b6ef417aa"
+        "revision" : "5c10fb44d312ff91865c030f044984e9ee495e8a"
       }
     }
   ],


### PR DESCRIPTION
- Simplified the code to use TiqrConfig to determine the hash
- Improved whitespaces in the popup viewcontrollers
- Moved the build phase script to the last place so it always runs successfully