### PR TITLE
TIQR-395: Fix back button behavior

### DIFF
--- a/EduID/Flows/CreateEduID/ViewControllers/CheckEmailViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CheckEmailViewController.swift
@@ -78,8 +78,4 @@ class CheckEmailViewController: CreateEduIDBaseViewController {
             goBack()
         }
     }
-    
-    override func goBack() {
-        navigationController?.popViewController(animated: true)
-    }
 }

--- a/EduID/Flows/CreateEduID/ViewModels/CreateEduIDEnterPersonalInfoViewModel.swift
+++ b/EduID/Flows/CreateEduID/ViewModels/CreateEduIDEnterPersonalInfoViewModel.swift
@@ -37,9 +37,7 @@ class CreateEduIDEnterPersonalInfoViewModel: NSObject {
         Task {
             do {
                 let account = CreateAccount(email: email, givenName: givenName, familyName: familyName, relyingPartClientId: AppAuthController.shared.clientId)
-                try await UserControllerAPI.createEduIDAccountWithRequestBuilder(createAccount: account)
-                    .execute()
-                    .body
+                let _ = try await UserControllerAPI.createEduIDAccount(createAccount: account)
                 createEduIDSuccessClosure?()
             } catch {
                 let errorResponse = error.eduIdResponseError()


### PR DESCRIPTION
The VC wasn't calling the default goBack() method which would change the current screen type, resulting in an incorrect screen type.