### PR TITLE
TIQR-455: Do not use day names in dates, cancel auth notification

### DIFF
--- a/EduID/SharedViews/ActivityControlCollapsible.swift
+++ b/EduID/SharedViews/ActivityControlCollapsible.swift
@@ -267,13 +267,6 @@ class ActivityControlCollapsible: ExpandableControl {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    static var dateFormatter: DateFormatter {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .full
-        return formatter
-    }
-    
-    static var isoDateFormatter = CodableHelper.dateFormatter
-    
+
+    static var isoDateFormatter = CodableHelper.dateFormatter    
 }

--- a/EduID/SharedViews/InstitutionControlCollapsible.swift
+++ b/EduID/SharedViews/InstitutionControlCollapsible.swift
@@ -182,7 +182,7 @@ class InstitutionControlCollapsible: ExpandableControl {
     
     static var dateFormatter: DateFormatter {
         let formatter = DateFormatter()
-        formatter.dateStyle = .full
+        formatter.dateStyle = .medium
         return formatter
     }
     

--- a/EduID/SharedViews/VerifiedInformationControlCollapsible.swift
+++ b/EduID/SharedViews/VerifiedInformationControlCollapsible.swift
@@ -181,7 +181,7 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
     
     static var dateFormatter: DateFormatter {
         let formatter = DateFormatter()
-        formatter.dateStyle = .full
+        formatter.dateStyle = .medium
         return formatter
     }
     

--- a/Notifications/NotificationService.swift
+++ b/Notifications/NotificationService.swift
@@ -23,7 +23,11 @@ class NotificationService: UNNotificationServiceExtension {
         let payload = bestAttemptContent?.userInfo
         let challenge = payload?["challenge"]
         let authenticationTimeout = payload?["authenticationTimeout"]
-        RecentNotifications(appGroup: appGroup).onNewNotification(timeOut: authenticationTimeout, challenge: challenge)
+        RecentNotifications(appGroup: appGroup).onNewNotification(
+            timeOut: authenticationTimeout,
+            challenge: challenge,
+            notificationId: request.identifier
+        )
         contentHandler(bestAttemptContent ?? UNMutableNotificationContent())
     }
     

--- a/eduID.xcodeproj/project.pbxproj
+++ b/eduID.xcodeproj/project.pbxproj
@@ -2782,7 +2782,7 @@
 			repositoryURL = "https://github.com/Tiqr/tiqr-app-core-ios";
 			requirement = {
 				kind = revision;
-				revision = 34d63500ebbe4d810a29a6dc1f76e59ce853d5fd;
+				revision = 833b7cc7001fc8abf45b98ab0cc41ed43ef6c91d;
 			};
 		};
 		4FF567D92A31D3FA00616341 /* XCRemoteSwiftPackageReference "TinyConstraints" */ = {

--- a/eduID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/eduID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,7 +51,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Tiqr/tiqr-app-core-ios",
       "state" : {
-        "revision" : "34d63500ebbe4d810a29a6dc1f76e59ce853d5fd"
+        "revision" : "833b7cc7001fc8abf45b98ab0cc41ed43ef6c91d"
       }
     }
   ],


### PR DESCRIPTION
This PR removes the name of the day from the date displays, to save some screen space primarily on smaller devices.
Also we update the core package and send the notification ID to the notification cache, so that core can cancel the notification once the app itself is opened instead of the notification.