### PR TITLE
TIQR-470: Remove linked account, show external linked accounts, linking success screen basics

### DIFF
--- a/EduID/Extensions/Error+Extension.swift
+++ b/EduID/Extensions/Error+Extension.swift
@@ -1,40 +1,68 @@
 import Foundation
 import OpenAPIClient
 
-extension Error {
-    func eduIdResponseError() -> (title: String, message: String, statusCode: Int) {
-        if let response = self as? ErrorResponse {
+// Custom error class to handle eduId API response errors
+class EduIdError: Error {
+    let title: String
+    let message: String
+    let statusCode: Int
+    
+    init(title: String, message: String, statusCode: Int) {
+        self.title = title
+        self.message = message
+        self.statusCode = statusCode
+    }
+    
+    // Factory method to generate CustomError from ErrorResponse
+    static func from(_ error: Error) -> EduIdError {
+        if let response = error as? ErrorResponse {
             switch response {
             case let .error(statusCode, _, _, _):
-                switch statusCode {
-                case 401:
-                    return (title: L.ResponseErrors.UnauthorizedTitle.localization,
-                            message: L.ResponseErrors.UnauthorizedText.localization,
-                            statusCode: statusCode)
-                case 403:
-                    return (title: L.ResponseErrors.SMSErrorTitle.localization,
-                            message: L.ResponseErrors.SMSErrorText.localization,
-                            statusCode: statusCode)
-                case 409:
-                    return (title: L.ResponseErrors.EmailInUse.Title.localization,
-                            message: L.ResponseErrors.EmailInUse.Description.localization,
-                            statusCode: statusCode)
-                case 412:
-                    return (title: L.ResponseErrors.ForbiddenDomainTitle.localization,
-                            message: L.ResponseErrors.ForbiddenDomainText.localization,
-                            statusCode: statusCode)
-                case -1:
-                    return (title: L.ResponseErrors.NoInternetAccessTitle.localization,
-                            message: L.ResponseErrors.NoInternetAccessText.localization,
-                            statusCode: statusCode)
-                    
-                default:
-                    return (title: "\(statusCode) \(L.ResponseErrors.NoInternetAccessTitle.localization)",
-                            message: "\(L.ResponseErrors.UnknownErrorText.localization) \(statusCode)",
-                            statusCode: statusCode)
-                }
+                return EduIdError.generateError(for: statusCode)
             }
         }
-        return (title: "",message: "", .zero)
+        return EduIdError(title: "Unknown Error", message: "An unknown error occurred.", statusCode: -1)
+    }
+    
+    // Generate the appropriate error based on the status code
+    private static func generateError(for statusCode: Int) -> EduIdError {
+        switch statusCode {
+        case 401:
+            return EduIdError(
+                title: L.ResponseErrors.UnauthorizedTitle.localization,
+                message: L.ResponseErrors.UnauthorizedText.localization,
+                statusCode: statusCode
+            )
+        case 403:
+            return EduIdError(
+                title: L.ResponseErrors.SMSErrorTitle.localization,
+                message: L.ResponseErrors.SMSErrorText.localization,
+                statusCode: statusCode
+            )
+        case 409:
+            return EduIdError(
+                title: L.ResponseErrors.EmailInUse.Title.localization,
+                message: L.ResponseErrors.EmailInUse.Description.localization,
+                statusCode: statusCode
+            )
+        case 412:
+            return EduIdError(
+                title: L.ResponseErrors.ForbiddenDomainTitle.localization,
+                message: L.ResponseErrors.ForbiddenDomainText.localization,
+                statusCode: statusCode
+            )
+        case -1:
+            return EduIdError(
+                title: L.ResponseErrors.NoInternetAccessTitle.localization,
+                message: L.ResponseErrors.NoInternetAccessText.localization,
+                statusCode: statusCode
+            )
+        default:
+            return EduIdError(
+                title: "\(statusCode) \(L.ResponseErrors.NoInternetAccessTitle.localization)",
+                message: "\(L.ResponseErrors.UnknownErrorText.localization) \(statusCode)",
+                statusCode: statusCode
+            )
+        }
     }
 }

--- a/EduID/Flows/Activity/ActivityViewController.swift
+++ b/EduID/Flows/Activity/ActivityViewController.swift
@@ -13,16 +13,16 @@ class ActivityViewController: BaseViewController {
     init(viewModel: ActivityViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        viewModel.dataFetchErrorClosure = { [weak self] title, message, statusCode in
+        viewModel.dataFetchErrorClosure = { [weak self] eduidError in
             guard let self else { return }
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            let alert = UIAlertController(title: eduidError.title, message: eduidError.message, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .default) { _ in
                 alert.dismiss(animated: true) {
-                    if statusCode == 401 {
+                    if eduidError.statusCode == 401 {
                         AppAuthController.shared.authorize(viewController: self)
                         self.dismiss(animated: false)
                         self.refreshDelegate?.requestScreenRefresh(for: .activity)
-                    } else if statusCode == -1 {
+                    } else if eduidError.statusCode == -1 {
                         self.dismiss(animated: true)
                     }
                 }

--- a/EduID/Flows/Activity/ActivityViewModel.swift
+++ b/EduID/Flows/Activity/ActivityViewModel.swift
@@ -9,7 +9,7 @@ class ActivityViewModel: NSObject {
     // - closures
     var dataAvailableClosure: ((PersonalInfoDataCallbackModel) -> Void)?
     var serviceRemovedClosure: ((LinkedAccount) -> Void)?
-    var dataFetchErrorClosure: ((String, String, Int) -> Void)?
+    var dataFetchErrorClosure: ((EduIdError) -> Void)?
     
     override init() {
         super.init()
@@ -37,9 +37,7 @@ class ActivityViewModel: NSObject {
     
     @MainActor
     private func processError(with error: Error) {
-        dataFetchErrorClosure?(error.eduIdResponseError().title,
-                               error.eduIdResponseError().message,
-                               error.eduIdResponseError().statusCode)
+        dataFetchErrorClosure?(EduIdError.from(error))
     }
     
     @MainActor

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDAddInstitutionViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDAddInstitutionViewController.swift
@@ -22,14 +22,14 @@ class CreateEduIDAddInstitutionViewController: CreateEduIDBaseViewController {
             self?.setupUI(model: model)
         }
         
-        viewModel.dataFetchErrorClosure = { [weak self] title, message, statusCode in
+        viewModel.dataFetchErrorClosure = { [weak self] eduidError in
             guard let self else { return }
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            let alert = UIAlertController(title: eduidError.title, message: eduidError.message, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .default) { _ in
                 alert.dismiss(animated: true) {
-                    if statusCode == 401 {
+                    if eduidError.statusCode == 401 {
                         AppAuthController.shared.authorize(viewController: self)
-                    } else if statusCode == -1 {
+                    } else if eduidError.statusCode == -1 {
                         self.dismiss(animated: true)
                     }
                 }
@@ -88,7 +88,7 @@ class CreateEduIDAddInstitutionViewController: CreateEduIDBaseViewController {
                 let givenNameControl = VerifiedInformationControlCollapsible(
                     title: givenName,
                     subtitle: L.Profile.VerifiedGivenName.localization,
-                    linkedAccount: linkedAccount,
+                    model: VerifiedInformationModel(linkedAccount: linkedAccount),
                     manageVerifiedInformationAction: nil,
                     expandable: false
                 )
@@ -99,7 +99,7 @@ class CreateEduIDAddInstitutionViewController: CreateEduIDBaseViewController {
                 let familyNameControl = VerifiedInformationControlCollapsible(
                     title: familyName,
                     subtitle: L.Profile.VerifiedFamilyName.localization,
-                    linkedAccount: linkedAccount,
+                    model: VerifiedInformationModel(linkedAccount: linkedAccount),
                     manageVerifiedInformationAction: nil,
                     expandable: false
                 )

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDEnterPhoneNumberViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDEnterPhoneNumberViewController.swift
@@ -169,8 +169,9 @@ extension CreateEduIDEnterPhoneNumberViewController {
 
 extension CreateEduIDEnterPhoneNumberViewController: AlertErrorHandlerDelegate {
     func presentAlert(with error: Error) {
-        let alertController = UIAlertController(title: error.eduIdResponseError().title,
-                                                message: error.eduIdResponseError().message,
+        let eduIdError = EduIdError.from(error)
+        let alertController = UIAlertController(title: eduIdError.title,
+                                                message: eduIdError.message,
                                                 preferredStyle: .alert)
         let alertAction = UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .cancel) { [weak self] _ in
             self?.verifyButton.isUserInteractionEnabled = true

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDEnterSMSViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDEnterSMSViewController.swift
@@ -40,8 +40,9 @@ class CreateEduIDEnterSMSViewController: PincodeBaseViewController {
 extension CreateEduIDEnterSMSViewController: AlertErrorHandlerDelegate {
     
     func presentAlert(with error: Error) {
-        let alertController = UIAlertController(title: error.eduIdResponseError().title,
-                                                message: error.eduIdResponseError().message,
+        let eduIdError = EduIdError.from(error)
+        let alertController = UIAlertController(title: eduIdError.title,
+                                                message: eduIdError.message,
                                                 preferredStyle: .alert)
         
         let alertAction = UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .cancel) { [weak self] _ in

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDFirstTimeDialogViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDFirstTimeDialogViewController.swift
@@ -144,8 +144,9 @@ class CreateEduIDFirstTimeDialogViewController: CreateEduIDBaseViewController {
 
 extension CreateEduIDFirstTimeDialogViewController: AlertErrorHandlerDelegate {
     func presentAlert(with error: Error) {
-        let alertController = UIAlertController(title: error.eduIdResponseError().title,
-                                                message: error.eduIdResponseError().message,
+        let eduIdError = EduIdError.from(error)
+        let alertController = UIAlertController(title: eduIdError.title,
+                                                message: eduIdError.message,
                                                 preferredStyle: .alert)
         let alertAction = UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .cancel)
         alertController.addAction(alertAction)

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDRegistrationCheckViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDRegistrationCheckViewController.swift
@@ -63,7 +63,8 @@ class CreateEduIDRegistrationCheckViewController: CreateEduIDBaseViewController 
             .receive(on: DispatchQueue.main)
             .sink { [weak self] snapShot in
                 if let snapShot {
-                    self?.presentAlert(with: snapShot.eduIdResponseError().title, and: snapShot.eduIdResponseError().message, for: .error)
+                    let eduIdError = EduIdError.from(snapShot)
+                    self?.presentAlert(with: eduIdError.title, and: eduIdError.message, for: .error)
                 }
             }.store(in: &cancellable)
     }

--- a/EduID/Flows/CreateEduID/ViewModels/CreateEduIDEnterPersonalInfoViewModel.swift
+++ b/EduID/Flows/CreateEduID/ViewModels/CreateEduIDEnterPersonalInfoViewModel.swift
@@ -40,7 +40,7 @@ class CreateEduIDEnterPersonalInfoViewModel: NSObject {
                 let _ = try await UserControllerAPI.createEduIDAccount(createAccount: account)
                 createEduIDSuccessClosure?()
             } catch {
-                let errorResponse = error.eduIdResponseError()
+                let errorResponse = EduIdError.from(error)
                 createEduIDErrorClosure?(errorResponse.title, errorResponse.message)
             }
         }

--- a/EduID/Flows/CreateEduID/ViewModels/CreateEduIDEnterSMSViewModel.swift
+++ b/EduID/Flows/CreateEduID/ViewModels/CreateEduIDEnterSMSViewModel.swift
@@ -15,7 +15,7 @@ class CreateEduIDEnterSMSViewModel: NSObject {
                     .body
                 smsEntryWasCorrect?(result)
             } catch {
-                let responseError = error.eduIdResponseError()
+                let responseError = EduIdError.from(error)
                 smsEntryFailed?(responseError.title, responseError.message)
             }
         }

--- a/EduID/Flows/PersonalInfo/PersonalInfoCoordinator.swift
+++ b/EduID/Flows/PersonalInfo/PersonalInfoCoordinator.swift
@@ -119,6 +119,12 @@ class PersonalInfoCoordinator: CoordinatorType, PersonalInfoViewControllerDelega
     func goBack(viewController: UIViewController) {
         navigationController?.popViewController(animated: true)
     }
+    
+    func goToLinkingSuccessScreen(linkedInstitution: String?, previousUserInfo: UserResponse?) {
+        let linkingSuccessViewController = LinkingSuccessViewController()
+        linkingSuccessViewController.viewModel = LinkingSuccessViewModel(linkedInstitution: linkedInstitution, previousUserResponse: previousUserInfo)
+        navigationController?.pushViewController(linkingSuccessViewController, animated: true)
+    }
 }
 
 extension PersonalInfoCoordinator: AccountLinkingErrorDelegate {

--- a/EduID/Flows/PersonalInfo/PersonalInfoCoordinator.swift
+++ b/EduID/Flows/PersonalInfo/PersonalInfoCoordinator.swift
@@ -82,8 +82,8 @@ class PersonalInfoCoordinator: CoordinatorType, PersonalInfoViewControllerDelega
         navigationController!.pushViewController(confirmDeleteViewController, animated: true)
     }
     
-    func goToYourVerifiedInformationScreen(linkedAccounts: [LinkedAccount]) {
-        let yourVerifiedInformationViewController = YourVerifiedInformationViewController(viewModel: YourVerifiedInformationViewModel(linkedAccounts: linkedAccounts))
+    func goToYourVerifiedInformationScreen(userResponse: UserResponse) {
+        let yourVerifiedInformationViewController = YourVerifiedInformationViewController(viewModel: YourVerifiedInformationViewModel(userResponse: userResponse))
         yourVerifiedInformationViewController.delegate = self
         navigationController!.pushViewController(yourVerifiedInformationViewController, animated: true)
     }

--- a/EduID/Flows/PersonalInfo/PersonalInfoViewController.swift
+++ b/EduID/Flows/PersonalInfo/PersonalInfoViewController.swift
@@ -61,6 +61,7 @@ class PersonalInfoViewController: UIViewController, ScreenWithScreenType {
         }
         
         NotificationCenter.default.addObserver(self, selector: #selector(showLinkingErrorScreen), name: .accountAlreadyLinked, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didAddLinkedInstitution), name: .didAddLinkedAccounts, object: nil)
     }
     
     required init?(coder: NSCoder) {
@@ -91,6 +92,14 @@ class PersonalInfoViewController: UIViewController, ScreenWithScreenType {
         let linkedAccountEmail = notification.userInfo?[Constants.UserInfoKey.linkedAccountEmail] as? String
         delegate?.goToAccountLinkingErrorScreen(linkedAccountEmail: linkedAccountEmail)
     }
+    
+    @objc
+    func didAddLinkedInstitution(_ notification: NSNotification) {
+        // User tried to link account, but it was already linked
+        let linkedInstitution = notification.userInfo?[Constants.UserInfoKey.linkedAccountInstitution] as? String
+        delegate?.goToLinkingSuccessScreen(linkedInstitution: linkedInstitution, previousUserInfo: viewModel.userResponse)
+    }
+    
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)

--- a/EduID/Flows/PersonalInfo/PersonalInfoViewControllerDelegate.swift
+++ b/EduID/Flows/PersonalInfo/PersonalInfoViewControllerDelegate.swift
@@ -13,7 +13,7 @@ protocol PersonalInfoViewControllerDelegate: AnyObject, NavigationDelegate {
     func goToDeleteAccount(viewController: UIViewController, personalInfo: UserResponse)
     func goToConfirmDeleteAccount(viewController: UIViewController, personalInfo: UserResponse)
     func goToAccountLinkingErrorScreen(linkedAccountEmail: String?)
-    func goToYourVerifiedInformationScreen(linkedAccounts: [LinkedAccount])
+    func goToYourVerifiedInformationScreen(userResponse: UserResponse)
     func goToVerifyYourIdentityScreen(viewController: UIViewController)
     func goToSelectYourBankScreen(viewController: UIViewController)
     func showConfirmEmailScreen(viewController: UIViewController, emailToVerify: String?)

--- a/EduID/Flows/PersonalInfo/PersonalInfoViewControllerDelegate.swift
+++ b/EduID/Flows/PersonalInfo/PersonalInfoViewControllerDelegate.swift
@@ -16,6 +16,7 @@ protocol PersonalInfoViewControllerDelegate: AnyObject, NavigationDelegate {
     func goToYourVerifiedInformationScreen(userResponse: UserResponse)
     func goToVerifyYourIdentityScreen(viewController: UIViewController)
     func goToSelectYourBankScreen(viewController: UIViewController)
+    func goToLinkingSuccessScreen(linkedInstitution: String?, previousUserInfo: UserResponse?)
     func showConfirmEmailScreen(viewController: UIViewController, emailToVerify: String?)
     func shouldUpdateData() -> Bool
     func deleteStateAndGoToHome()

--- a/EduID/Flows/PersonalInfo/PersonalInfoViewModel.swift
+++ b/EduID/Flows/PersonalInfo/PersonalInfoViewModel.swift
@@ -8,7 +8,7 @@ class PersonalInfoViewModel: NSObject {
     // - closures
     var dataAvailableClosure: ((PersonalInfoDataCallbackModel) -> Void)?
     var serviceRemovedClosure: ((LinkedAccount) -> Void)?
-    var dataFetchErrorClosure: ((String, String, Int) -> Void)?
+    var dataFetchErrorClosure: ((EduIdError) -> Void)?
     private let defaults = UserDefaults.standard
     
     var viewController: CreateEduIDAddInstitutionViewController?
@@ -35,9 +35,7 @@ class PersonalInfoViewModel: NSObject {
     
     @MainActor
     private func processError(with error: Error) {
-        dataFetchErrorClosure?(error.eduIdResponseError().title,
-                               error.eduIdResponseError().message,
-                               error.eduIdResponseError().statusCode)
+        dataFetchErrorClosure?(EduIdError.from(error))
     }
     
     @MainActor

--- a/EduID/Flows/PersonalInfo/YourVerifiedInformation/YourVerifiedInformationViewController.swift
+++ b/EduID/Flows/PersonalInfo/YourVerifiedInformation/YourVerifiedInformationViewController.swift
@@ -108,7 +108,7 @@ class YourVerifiedInformationViewController: UIViewController, ScreenWithScreenT
         var isFirstAffiliation = true
         
         // From institution header
-        for linkedAccount in viewModel.linkedAccounts {
+        for linkedAccount in (viewModel.userResponse.linkedAccounts ?? []) {
             let separator = UIView()
             separator.backgroundColor = .lightGray
             separator.height(1)
@@ -226,7 +226,7 @@ class YourVerifiedInformationViewController: UIViewController, ScreenWithScreenT
                 attributes: AttributedStringHelper.attributes(font: .sourceSansProRegular(size: 12), color: .grayGhost, lineSpacing: 6)
             ))
             removeLink.setAttributedTitle(clickableTitle, for: .normal)
-            removeLink.tag = (viewModel.linkedAccounts.firstIndex(of: linkedAccount))!
+            removeLink.tag = (viewModel.userResponse.linkedAccounts!.firstIndex(of: linkedAccount))!
             removeLinkedAccountContainer.addSubview(removeLink)
             removeLink.leftToRight(of: removeIcon, offset: 13)
             removeLink.centerYToSuperview()
@@ -251,7 +251,7 @@ class YourVerifiedInformationViewController: UIViewController, ScreenWithScreenT
     
     @objc func removeLinkedAccount(sender: Any) {
         let index = (sender as! UIButton).tag
-        let account = viewModel.linkedAccounts[index]
+        let account = viewModel.userResponse.linkedAccounts![index]
         // - alert to confirm service removal
         let alert = UIAlertController(
             title: L.Profile.RemoveServicePrompt.Title.localization,

--- a/EduID/Flows/PersonalInfo/YourVerifiedInformation/YourVerifiedInformationViewModel.swift
+++ b/EduID/Flows/PersonalInfo/YourVerifiedInformation/YourVerifiedInformationViewModel.swift
@@ -17,32 +17,84 @@ class YourVerifiedInformationViewModel {
     }
     
     func removeLinkedAccount(
-        _ linkedAccount: LinkedAccount,
+        request: UpdateLinkedAccountRequest,
         onRemoved: @escaping () -> Void,
         onError: @escaping (Error) -> Void
     ) {
         Task {
             do {
-                let result = try await UserControllerAPI.removeUserLinkedAccountsWithRequestBuilder(updateLinkedAccountRequest: UpdateLinkedAccountRequest(
-                    eduPersonPrincipalName: linkedAccount.eduPersonPrincipalName,
-                    subjectId: linkedAccount.subjectId,
-                    external: linkedAccount.external,
-                    idpScoping: nil
-                    )
-                )
+                let result = try await UserControllerAPI.removeUserLinkedAccountsWithRequestBuilder(updateLinkedAccountRequest: request)
                     .execute()
                     .body
-                
-                if !(result.linkedAccounts?.contains(linkedAccount) ?? true) {
-                    DispatchQueue.main.async { [weak self] in
-                        guard let self else { return }
-                        onRemoved()
-                    }
+                DispatchQueue.main.async {
+                    onRemoved()
                 }
             } catch let error {
                 assertionFailure(error.localizedDescription)
                 onError(error)
             }
         }
+    }
+}
+
+extension UserResponse {
+    func getAllModels() -> [VerifiedInformationModel] {
+        var result = [VerifiedInformationModel]()
+        result.append(contentsOf: linkedAccounts?.map { VerifiedInformationModel(linkedAccount: $0) } ?? [])
+        result.append(contentsOf: externalLinkedAccounts?.map { VerifiedInformationModel(externalLinkedAccount: $0) } ?? [])
+        return result
+    }
+}
+
+
+class VerifiedInformationModel: Equatable {
+    let givenName: String?
+    let familyName: String?
+    let providerName: String
+    let createdAt: Int64?
+    let expiresAt: Int64?
+    let eduPersonAffiliations: [String]?
+    
+    let removeRequest: UpdateLinkedAccountRequest
+    
+    init(linkedAccount: LinkedAccount) {
+        givenName = linkedAccount.givenName
+        familyName = linkedAccount.familyName
+        providerName = linkedAccount.schacHomeOrganization ?? linkedAccount.institutionIdentifier ?? ""
+        createdAt = linkedAccount.createdAt
+        expiresAt = linkedAccount.expiresAt
+        eduPersonAffiliations = linkedAccount.eduPersonAffiliations
+        removeRequest = UpdateLinkedAccountRequest(
+            eduPersonPrincipalName: linkedAccount.eduPersonPrincipalName,
+            subjectId: linkedAccount.subjectId,
+            external: linkedAccount.external,
+            idpScoping: nil
+        )
+    }
+    
+    init(externalLinkedAccount: ExternalLinkedAccount) {
+        givenName = externalLinkedAccount.firstName
+        familyName = externalLinkedAccount.preferredLastName ?? externalLinkedAccount.legalLastName
+        providerName = externalLinkedAccount.issuer?.name ?? externalLinkedAccount.issuer?.id ?? "?"
+        createdAt = externalLinkedAccount.createdAt
+        expiresAt = externalLinkedAccount.expiresAt
+        eduPersonAffiliations = nil
+        removeRequest = UpdateLinkedAccountRequest(
+            eduPersonPrincipalName: nil,
+            subjectId: externalLinkedAccount.subjectId,
+            external: externalLinkedAccount.external,
+            idpScoping: externalLinkedAccount.idpScoping?.rawValue
+        )
+    }
+    
+    // Conform to the Equatable protocol
+    static func == (lhs: VerifiedInformationModel, rhs: VerifiedInformationModel) -> Bool {
+        return lhs.givenName == rhs.givenName &&
+               lhs.familyName == rhs.familyName &&
+               lhs.providerName == rhs.providerName &&
+               lhs.createdAt == rhs.createdAt &&
+               lhs.expiresAt == rhs.expiresAt &&
+               lhs.eduPersonAffiliations == rhs.eduPersonAffiliations &&
+               lhs.removeRequest == rhs.removeRequest
     }
 }

--- a/EduID/Flows/PersonalInfo/YourVerifiedInformation/YourVerifiedInformationViewModel.swift
+++ b/EduID/Flows/PersonalInfo/YourVerifiedInformation/YourVerifiedInformationViewModel.swift
@@ -10,10 +10,10 @@ import OpenAPIClient
 
 class YourVerifiedInformationViewModel {
     
-    let linkedAccounts: [LinkedAccount]
+    let userResponse: UserResponse
     
-    init(linkedAccounts: [LinkedAccount]) {
-        self.linkedAccounts = linkedAccounts
+    init(userResponse: UserResponse) {
+        self.userResponse = userResponse
     }
     
     func removeLinkedAccount(

--- a/EduID/Flows/Security/SecurityOverviewViewController.swift
+++ b/EduID/Flows/Security/SecurityOverviewViewController.swift
@@ -17,16 +17,16 @@ class SecurityOverviewViewController: UIViewController, ScreenWithScreenType {
     init(viewModel: SecurityOverviewViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        viewModel.dataFetchErrorClosure = {  [weak self] title, message, statusCode in
+        viewModel.dataFetchErrorClosure = {  [weak self] eduidError in
             guard let self else { return }
-            let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+            let alert = UIAlertController(title: eduidError.title, message: eduidError.message, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .default) { _ in
                 alert.dismiss(animated: true) {
-                    if statusCode == 401 {
+                    if eduidError.statusCode == 401 {
                         AppAuthController.shared.authorize(viewController: self)
                         self.dismiss(animated: false)
                         self.refreshDelegate?.requestScreenRefresh(for: .security)
-                    } else if statusCode == -1 {
+                    } else if eduidError.statusCode == -1 {
                         self.dismiss(animated: true)
                     }
                 }

--- a/EduID/Flows/Security/SecurityOverviewViewModel.swift
+++ b/EduID/Flows/Security/SecurityOverviewViewModel.swift
@@ -11,7 +11,7 @@ import OpenAPIClient
 class SecurityOverviewViewModel {
     
     var personalInfo: UserResponse? = nil
-    var dataFetchErrorClosure: ((String, String, Int) -> Void)?
+    var dataFetchErrorClosure: ((EduIdError) -> Void)?
     
     func getData() async throws -> UserResponse? {
         do {
@@ -25,8 +25,6 @@ class SecurityOverviewViewModel {
     
     @MainActor
     private func processError(with error: Error) {
-        dataFetchErrorClosure?(error.eduIdResponseError().title,
-                               error.eduIdResponseError().message,
-                               error.eduIdResponseError().statusCode)
+        dataFetchErrorClosure?(EduIdError.from(error))
     }
 }

--- a/EduID/Flows/VerifyIdentity/LinkingSuccess/LinkingSuccessViewController.swift
+++ b/EduID/Flows/VerifyIdentity/LinkingSuccess/LinkingSuccessViewController.swift
@@ -12,7 +12,7 @@ class LinkingSuccessViewController: BaseViewController {
     
     var delegate: PersonalInfoViewControllerDelegate?
     
-    var viewModel = LinkingSuccessViewModel()
+    var viewModel: LinkingSuccessViewModel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,6 +26,11 @@ class LinkingSuccessViewController: BaseViewController {
             }
         }
         viewModel.getData()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        screenType.configureNavigationItem(item: navigationItem, target: self, action: #selector(dismissInfoScreen))
     }
     
     private func handleError(_ error: Error) {
@@ -54,17 +59,14 @@ class LinkingSuccessViewController: BaseViewController {
 
         // - Main title
         let mainTitle = UILabel.posterTextLabelBicolor(
-            text: L.SelectYourBank.Title.localization,
+            text: L.LinkingSuccess.Title.localization,
             size: 24,
-            primary: L.SelectYourBank.Title.localization
+            primary: L.LinkingSuccess.Title.localization
         )
         
         // - Description below title
         let mainDescriptionParent = UIView()
-        let mainDescription = UILabel.subtitleLabel(
-            text: L.SelectYourBank.Subtitle.Full.localization, // TODO use correct title and message
-            partBold: L.SelectYourBank.Subtitle.HighlightedPart.localization
-        )
+        let mainDescription = UILabel.subtitleLabel(text: L.LinkingSuccess.Subtitle.localization)
         mainDescriptionParent.addSubview(mainDescription)
         mainDescription.edges(to: mainDescriptionParent)
         
@@ -77,15 +79,39 @@ class LinkingSuccessViewController: BaseViewController {
         stack.spacing = 24
         scrollView.addSubview(stack)
         
-        stack.edges(to: scrollView, insets: TinyEdgeInsets(top: 24, left: 0, bottom: 0, right: 0))
+        let buttonStack = UIStackView()
+        view.addSubview(buttonStack)
+        buttonStack.widthToSuperview(offset: -48)
+        buttonStack.centerXToSuperview()
+        buttonStack.spacing = 24
+        buttonStack.bottomToSuperview(usingSafeArea: true)
+        
+        stack.edges(to: scrollView, excluding: .bottom, insets: TinyEdgeInsets(top: 24, left: 0, bottom: 0, right: 0))
+        stack.bottomToTop(of: buttonStack)
         stack.width(to: scrollView, offset: 0)
         stack.setCustomSpacing(4, after: mainDescriptionParent)
         
         mainTitle.widthToSuperview(offset: -48)
         mainDescriptionParent.widthToSuperview(offset: -48)
         
-        if userResponse != nil {
-            // TODO
+        if let userResponse {
+            let addedAccount = viewModel.getAddedAccount()
+            let isFirstLinkedAccount = (userResponse.linkedAccounts?.count ?? 0) + (userResponse.externalLinkedAccounts?.count ?? 0) < 2
+            buttonStack.axis = .vertical
+            if let addedAccount {
+                if let verifiedFirstname = addedAccount.givenName {
+                    
+                }
+            }
+            if isFirstLinkedAccount || addedAccount == nil {
+                let continueButton = EduIDButton(type: .primary, buttonTitle: L.LinkingSuccess.Button.Continue.localization)
+                buttonStack.addArrangedSubview(continueButton)
+            } else {
+                let yesButton = EduIDButton(type: .primary, buttonTitle: L.LinkingSuccess.Button.YesPlease.localization)
+                buttonStack.addArrangedSubview(yesButton)
+                let noButton = EduIDButton(type: .naked, buttonTitle: L.LinkingSuccess.Button.NoThanks.localization)
+                buttonStack.addArrangedSubview(noButton)
+            }
         } else {
             let loadingIndicator = UIActivityIndicatorView()
             stack.addArrangedSubview(loadingIndicator)
@@ -93,6 +119,14 @@ class LinkingSuccessViewController: BaseViewController {
             loadingIndicator.widthToSuperview()
             loadingIndicator.startAnimating()
         }
+        
+        let spacer = UIView()
+        spacer.setContentHuggingPriority(.defaultHigh, for: .vertical)
+        stack.addArrangedSubview(spacer)
+    }
+    
+    @objc func dismissInfoScreen() {
+        delegate?.goBack(viewController: self)
     }
     
 }

--- a/EduID/Flows/VerifyIdentity/LinkingSuccess/LinkingSuccessViewController.swift
+++ b/EduID/Flows/VerifyIdentity/LinkingSuccess/LinkingSuccessViewController.swift
@@ -1,0 +1,100 @@
+//
+//  LinkingSuccessViewController.swift
+//  eduID
+//
+//  Created by Dániel Zolnai on 2024. 10. 10..
+//
+import OpenAPIClient
+import UIKit
+import TinyConstraints
+
+class LinkingSuccessViewController: BaseViewController {
+    
+    var delegate: PersonalInfoViewControllerDelegate?
+    
+    var viewModel = LinkingSuccessViewModel()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        screenType = .linkingSuccessScreen
+        setupUI(viewModel.userResponse)
+        viewModel.dataHandler = { [weak self] result in
+            if case .success(let userResponse) = result {
+                self?.setupUI(userResponse)
+            } else if case .failure(let error) = result {
+                self?.handleError(error)
+            }
+        }
+        viewModel.getData()
+    }
+    
+    private func handleError(_ error: Error) {
+        let errorTitle = (error as? EduIdError)?.title ?? error.localizedFromApi
+        let errorMessage = (error as? EduIdError)?.message ?? error.localizedDescription
+        let alert = UIAlertController(title: errorTitle, message: errorMessage, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .default) { _ in
+            alert.dismiss(animated: true) {
+                self.dismiss(animated: true)
+            }
+        })
+        self.present(alert, animated: true)
+      }
+    
+    func setupUI(_ userResponse: UserResponse?) {
+        // Remove any previous views
+        view.subviews.forEach {
+            $0.removeFromSuperview()
+        }
+        // - scroll view
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.contentInsetAdjustmentBehavior = .always
+        view.addSubview(scrollView)
+        scrollView.edgesToSuperview()
+
+        // - Main title
+        let mainTitle = UILabel.posterTextLabelBicolor(
+            text: L.SelectYourBank.Title.localization,
+            size: 24,
+            primary: L.SelectYourBank.Title.localization
+        )
+        
+        // - Description below title
+        let mainDescriptionParent = UIView()
+        let mainDescription = UILabel.subtitleLabel(
+            text: L.SelectYourBank.Subtitle.Full.localization, // TODO use correct title and message
+            partBold: L.SelectYourBank.Subtitle.HighlightedPart.localization
+        )
+        mainDescriptionParent.addSubview(mainDescription)
+        mainDescription.edges(to: mainDescriptionParent)
+        
+        // - create the stackview
+        let stack = UIStackView(arrangedSubviews: [mainTitle, mainDescriptionParent])
+        stack.axis = .vertical
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.distribution = .fill
+        stack.alignment = .center
+        stack.spacing = 24
+        scrollView.addSubview(stack)
+        
+        stack.edges(to: scrollView, insets: TinyEdgeInsets(top: 24, left: 0, bottom: 0, right: 0))
+        stack.width(to: scrollView, offset: 0)
+        stack.setCustomSpacing(4, after: mainDescriptionParent)
+        
+        mainTitle.widthToSuperview(offset: -48)
+        mainDescriptionParent.widthToSuperview(offset: -48)
+        
+        if userResponse != nil {
+            // TODO
+        } else {
+            let loadingIndicator = UIActivityIndicatorView()
+            stack.addArrangedSubview(loadingIndicator)
+            loadingIndicator.height(80)
+            loadingIndicator.widthToSuperview()
+            loadingIndicator.startAnimating()
+        }
+    }
+    
+}
+    
+    

--- a/EduID/Flows/VerifyIdentity/LinkingSuccess/LinkingSuccessViewModel.swift
+++ b/EduID/Flows/VerifyIdentity/LinkingSuccess/LinkingSuccessViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  LinkingSuccessViewModel.swift
+//  eduID
+//
+//  Created by Dániel Zolnai on 2024. 10. 10..
+//
+import OpenAPIClient
+import UIKit
+
+class LinkingSuccessViewModel: NSObject {
+    
+    var userResponse: UserResponse?
+    var dataHandler: ((Result<UserResponse, Error>) -> Void)?
+    
+    func getData() {
+        Task {
+            do {
+                try await userResponse = UserControllerAPI.meWithRequestBuilder()
+                    .execute()
+                    .body
+                await processUserData()
+            } catch {
+                await processError(with: error)
+            }
+        }
+    }
+    
+    @MainActor
+    private func processError(with error: Error) {
+        dataHandler?(.failure(EduIdError.from(error)))
+    }
+    
+    @MainActor
+    private func processUserData() {
+        guard let userResponse = userResponse else { return }
+        dataHandler?(.success(userResponse))
+    }
+    
+}

--- a/EduID/Flows/VerifyIdentity/LinkingSuccess/LinkingSuccessViewModel.swift
+++ b/EduID/Flows/VerifyIdentity/LinkingSuccess/LinkingSuccessViewModel.swift
@@ -9,8 +9,16 @@ import UIKit
 
 class LinkingSuccessViewModel: NSObject {
     
+    let linkedInstitution: String?
+    let previousUserResponse: UserResponse?
+    
     var userResponse: UserResponse?
     var dataHandler: ((Result<UserResponse, Error>) -> Void)?
+    
+    init(linkedInstitution: String?, previousUserResponse: UserResponse?) {
+        self.linkedInstitution = linkedInstitution
+        self.previousUserResponse = previousUserResponse
+    }
     
     func getData() {
         Task {
@@ -23,6 +31,37 @@ class LinkingSuccessViewModel: NSObject {
                 await processError(with: error)
             }
         }
+    }
+    
+    func getAddedAccount() -> VerifiedInformationModel? {
+        guard let userResponse else {
+            assertionFailure("Do not call this method before getData() finishes successfully!")
+            return nil
+        }
+        if let linkedInstitution {
+            if let linkedAccount = userResponse.linkedAccounts?.first(where: { $0.eduPersonPrincipalName == linkedInstitution }) {
+                return VerifiedInformationModel(linkedAccount: linkedAccount)
+            }
+            if let externalLinkedAccount = userResponse.externalLinkedAccounts?.first(where: { $0.issuer?.id == linkedInstitution }) {
+                return VerifiedInformationModel(externalLinkedAccount: externalLinkedAccount)
+            }
+        }
+        if let previousUserResponse {
+            // Fallback: check if there are any new linked (external) accounts
+            let allPreviousAccounts = previousUserResponse.linkedAccounts?.map { $0.eduPersonPrincipalName } ?? []
+            let allPreviousExternalAccount = previousUserResponse.externalLinkedAccounts?.map(\.issuer?.id) ?? []
+            for linkedAccount in (userResponse.linkedAccounts ?? []) {
+                if !allPreviousAccounts.contains(linkedAccount.eduPersonPrincipalName) {
+                    return VerifiedInformationModel(linkedAccount: linkedAccount)
+                }
+            }
+            for externalLinkedAccount in (userResponse.externalLinkedAccounts ?? []) {
+                if !allPreviousExternalAccount.contains(externalLinkedAccount.issuer?.id) {
+                    return VerifiedInformationModel(externalLinkedAccount: externalLinkedAccount)
+                }
+            }
+        }
+        return nil
     }
     
     @MainActor

--- a/EduID/Flows/VerifyIdentity/SelectYourBank/SelectYourBankViewController.swift
+++ b/EduID/Flows/VerifyIdentity/SelectYourBank/SelectYourBankViewController.swift
@@ -16,7 +16,7 @@ class SelectYourBankViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        screenType = .selectYourBank
+        screenType = .selectYourBankScreen
         setupUI(issuers: viewModel.issuers)
         viewModel.dataHandler = { [weak self] result in
             guard let self else { return }

--- a/EduID/Flows/VerifyIdentity/SelectYourBank/SelectYourBankViewModel.swift
+++ b/EduID/Flows/VerifyIdentity/SelectYourBank/SelectYourBankViewModel.swift
@@ -76,10 +76,11 @@ class SelectYourBankViewModel: NSObject {
     }
     
     private func handleError(_ error: Error) -> SelectYourBankError {
+        let eduIdError = EduIdError.from(error)
         return SelectYourBankError(
-            title: error.eduIdResponseError().title,
-            message: error.eduIdResponseError().message,
-            statusCode: error.eduIdResponseError().statusCode
+            title: eduIdError.title,
+            message: eduIdError.message,
+            statusCode: eduIdError.statusCode
         )
     }
 }

--- a/EduID/Flows/VerifyIdentity/VerifyIdentityViewModel.swift
+++ b/EduID/Flows/VerifyIdentity/VerifyIdentityViewModel.swift
@@ -9,7 +9,7 @@ import OpenAPIClient
 
 class VerifyIdentityViewModel: NSObject {
     
-    var dataFetchErrorClosure: ((String, String, Int) -> Void)?
+    var dataFetchErrorClosure: ((EduIdError) -> Void)?
     
     func startLinkingInstitution(_ control: VerifyIdentityControl) {
         control.isLoading = true
@@ -47,9 +47,6 @@ class VerifyIdentityViewModel: NSObject {
     @MainActor
     private func processError(with error: Error, control: VerifyIdentityControl) {
         control.isLoading = false
-        dataFetchErrorClosure?(error.eduIdResponseError().title,
-                               error.eduIdResponseError().message,
-                               error.eduIdResponseError().statusCode)
+        dataFetchErrorClosure?(EduIdError.from(error))
     }
-    
 }

--- a/EduID/Localizable.swift
+++ b/EduID/Localizable.swift
@@ -6932,4 +6932,56 @@ public struct L {
             )
         }
     }
+    public struct LinkingSuccess {
+        public static let Title = LocaliciousData(
+            accessibilityIdentifier: "LinkingSuccess.Title",
+            accessibilityHintKey: nil,
+            accessibilityLabelKey: nil,
+            accessibilityValueKey: nil,
+            translationKey: "LinkingSuccess.Title.COPY",
+            translationArgs: []
+        )
+        public static let Subtitle = LocaliciousData(
+            accessibilityIdentifier: "LinkingSuccess.Subtitle",
+            accessibilityHintKey: nil,
+            accessibilityLabelKey: nil,
+            accessibilityValueKey: nil,
+            translationKey: "LinkingSuccess.Subtitle.COPY",
+            translationArgs: []
+        )
+        public static let SubtitlePreferInstitution = LocaliciousData(
+            accessibilityIdentifier: "LinkingSuccess.SubtitlePreferInstitution",
+            accessibilityHintKey: nil,
+            accessibilityLabelKey: nil,
+            accessibilityValueKey: nil,
+            translationKey: "LinkingSuccess.SubtitlePreferInstitution.COPY",
+            translationArgs: []
+        )
+        public struct Button {
+            public static let Continue = LocaliciousData(
+                accessibilityIdentifier: "LinkingSuccess.Button.Continue",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: "LinkingSuccess.Button.Continue.COPY",
+                translationArgs: []
+            )
+            public static let YesPlease = LocaliciousData(
+                accessibilityIdentifier: "LinkingSuccess.Button.YesPlease",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: "LinkingSuccess.Button.YesPlease.COPY",
+                translationArgs: []
+            )
+            public static let NoThanks = LocaliciousData(
+                accessibilityIdentifier: "LinkingSuccess.Button.NoThanks",
+                accessibilityHintKey: nil,
+                accessibilityLabelKey: nil,
+                accessibilityValueKey: nil,
+                translationKey: "LinkingSuccess.Button.NoThanks.COPY",
+                translationArgs: []
+            )
+        }
+    }
 }

--- a/EduID/Resources/General/en.lproj/Localizable.strings
+++ b/EduID/Resources/General/en.lproj/Localizable.strings
@@ -825,3 +825,9 @@ We will text you a code to verify your number.
 "SelectYourBank.IdinkLink.COPY" = "https://www.idin.nl/en/";
 "SelectYourBank.BankNotInList.Full.COPY" = "If your bank is not shown in the list, please select another method";
 "SelectYourBank.BankNotInList.HighlightedPart.COPY" = "another method";
+"LinkingSuccess.Title.COPY" = "Your personal info 🎉";
+"LinkingSuccess.Subtitle.COPY" = "The following information has been added to your eduID.";
+"LinkingSuccess.SubtitlePreferInstitution.COPY" = "Do you want to use the following information to be the default information shared with applications?";
+"LinkingSuccess.Button.Continue.COPY" = "Continue";
+"LinkingSuccess.Button.YesPlease.COPY" = "Yes, please";
+"LinkingSuccess.Button.NoThanks.COPY" = "No, thanks";

--- a/EduID/Resources/General/nl.lproj/Localizable.strings
+++ b/EduID/Resources/General/nl.lproj/Localizable.strings
@@ -826,7 +826,7 @@ We sturen je een code om je nummer te verifiëren.
 "SelectYourBank.BankNotInList.Full.COPY" = "Staat jouw bank niet in deze lijst, selecteer dan een andere methode";
 "SelectYourBank.BankNotInList.HighlightedPart.COPY" = "andere methode";
 "LinkingSuccess.Title.COPY" = "Jouw persoonlijk informatie 🎉";
-"LinkingSuccess.Subtitle.COPY" = "";
+"LinkingSuccess.Subtitle.COPY" = "De volgende informatie is toegevoegd aan jouw eduID account.";
 "LinkingSuccess.SubtitlePreferInstitution.COPY" = "Wil je de volgende informatie, gebruiken als standaardinformatie om met diensten te delen?";
 "LinkingSuccess.Button.Continue.COPY" = "Ga door";
 "LinkingSuccess.Button.YesPlease.COPY" = "Ja, graag";

--- a/EduID/Resources/General/nl.lproj/Localizable.strings
+++ b/EduID/Resources/General/nl.lproj/Localizable.strings
@@ -825,3 +825,9 @@ We sturen je een code om je nummer te verifiëren.
 "SelectYourBank.IdinkLink.COPY" = "https://www.idin.nl/";
 "SelectYourBank.BankNotInList.Full.COPY" = "Staat jouw bank niet in deze lijst, selecteer dan een andere methode";
 "SelectYourBank.BankNotInList.HighlightedPart.COPY" = "andere methode";
+"LinkingSuccess.Title.COPY" = "Jouw persoonlijk informatie 🎉";
+"LinkingSuccess.Subtitle.COPY" = "";
+"LinkingSuccess.SubtitlePreferInstitution.COPY" = "Wil je de volgende informatie, gebruiken als standaardinformatie om met diensten te delen?";
+"LinkingSuccess.Button.Continue.COPY" = "Ga door";
+"LinkingSuccess.Button.YesPlease.COPY" = "Ja, graag";
+"LinkingSuccess.Button.NoThanks.COPY" = "Nee, bedankt";

--- a/EduID/SharedViews/VerifiedInformationControlCollapsible.swift
+++ b/EduID/SharedViews/VerifiedInformationControlCollapsible.swift
@@ -15,7 +15,7 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
     //MARK: - init
     init(title: String,
          subtitle: String,
-         linkedAccount: LinkedAccount,
+         model: VerifiedInformationModel,
          manageVerifiedInformationAction: (() -> Void)?,
          expandable: Bool = true,
          leftEmoji: String? = nil,
@@ -26,9 +26,7 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
         setupUI(
             title: title,
             subtitle: subtitle,
-            verifiedBy: linkedAccount.schacHomeOrganization ?? linkedAccount.institutionIdentifier ?? "",
-            createdAt: linkedAccount.createdAt,
-            expiresAt: linkedAccount.expiresAt,
+            model: model,
             expandable: expandable,
             leftEmoji: leftEmoji,
             rightIcon: rightIcon)
@@ -37,38 +35,11 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
         }
     }
     
-    //MARK: - init
-    init(title: String,
-         subtitle: String,
-         externalLinkedAccount: ExternalLinkedAccount,
-         manageVerifiedInformationAction: (() -> Void)?,
-         expandable: Bool = true,
-         leftEmoji: String? = nil,
-         rightIcon: UIImage? = nil
-    ) {
-        self.manageVerifiedInformationAction = manageVerifiedInformationAction
-        super.init()
-        setupUI(
-            title: title,
-            subtitle: subtitle,
-            verifiedBy: externalLinkedAccount.serviceID ?? "",
-            createdAt: externalLinkedAccount.createdAt,
-            expiresAt: externalLinkedAccount.expiresAt,
-            expandable: expandable,
-            leftEmoji: leftEmoji,
-            rightIcon: rightIcon)
-        if !expandable {
-            self.gestureRecognizers?.forEach { removeGestureRecognizer($0) }
-        }
-    }
-            
     //MARK: - setup UI
     private func setupUI(
         title: String,
         subtitle: String,
-        verifiedBy: String,
-        createdAt: Int64?,
-        expiresAt: Int64?,
+        model: VerifiedInformationModel,
         expandable: Bool,
         leftEmoji: String?,
         rightIcon: UIImage?
@@ -129,10 +100,10 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
         // Verified by
         let verifiedByLabel = UILabel()
         let verifiedByString = NSMutableAttributedString(
-            string: L.Profile.VerifiedBy(args: verifiedBy).localization,
+            string: L.Profile.VerifiedBy(args: model.providerName).localization,
             attributes: AttributedStringHelper.attributes(font: .sourceSansProBold(size: 12), color: .grayGhost, lineSpacing: 6)
         )
-        if let createdAt {
+        if let createdAt = model.createdAt {
             let createdAtDate = Date(timeIntervalSince1970: TimeInterval(createdAt / 1000))
             verifiedByString.append(NSAttributedString(
                 string: "\n" + L.Profile.LinkedAccountCreatedAt.localization,
@@ -143,7 +114,7 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
                 attributes: AttributedStringHelper.attributes(font: .sourceSansProBold(size: 12), color: .grayGhost, lineSpacing: 6)
             ))
         }
-        if let expiresAt {
+        if let expiresAt = model.expiresAt {
             let expiresAtDate = Date(timeIntervalSince1970: TimeInterval(expiresAt / 1000))
             verifiedByString.append(NSAttributedString(
                 string: "\n" + L.Profile.LinkedAccountValidUntil.localization,

--- a/EduID/SharedViews/VerifiedInformationControlCollapsible.swift
+++ b/EduID/SharedViews/VerifiedInformationControlCollapsible.swift
@@ -26,7 +26,34 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
         setupUI(
             title: title,
             subtitle: subtitle,
-            linkedAccount: linkedAccount,
+            verifiedBy: linkedAccount.schacHomeOrganization ?? linkedAccount.institutionIdentifier ?? "",
+            createdAt: linkedAccount.createdAt,
+            expiresAt: linkedAccount.expiresAt,
+            expandable: expandable,
+            leftEmoji: leftEmoji,
+            rightIcon: rightIcon)
+        if !expandable {
+            self.gestureRecognizers?.forEach { removeGestureRecognizer($0) }
+        }
+    }
+    
+    //MARK: - init
+    init(title: String,
+         subtitle: String,
+         externalLinkedAccount: ExternalLinkedAccount,
+         manageVerifiedInformationAction: (() -> Void)?,
+         expandable: Bool = true,
+         leftEmoji: String? = nil,
+         rightIcon: UIImage? = nil
+    ) {
+        self.manageVerifiedInformationAction = manageVerifiedInformationAction
+        super.init()
+        setupUI(
+            title: title,
+            subtitle: subtitle,
+            verifiedBy: externalLinkedAccount.serviceID ?? "",
+            createdAt: externalLinkedAccount.createdAt,
+            expiresAt: externalLinkedAccount.expiresAt,
             expandable: expandable,
             leftEmoji: leftEmoji,
             rightIcon: rightIcon)
@@ -39,7 +66,9 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
     private func setupUI(
         title: String,
         subtitle: String,
-        linkedAccount: LinkedAccount,
+        verifiedBy: String,
+        createdAt: Int64?,
+        expiresAt: Int64?,
         expandable: Bool,
         leftEmoji: String?,
         rightIcon: UIImage?
@@ -100,10 +129,10 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
         // Verified by
         let verifiedByLabel = UILabel()
         let verifiedByString = NSMutableAttributedString(
-            string: L.Profile.VerifiedBy(args: linkedAccount.schacHomeOrganization ?? linkedAccount.institutionIdentifier ?? "").localization,
+            string: L.Profile.VerifiedBy(args: verifiedBy).localization,
             attributes: AttributedStringHelper.attributes(font: .sourceSansProBold(size: 12), color: .grayGhost, lineSpacing: 6)
         )
-        if let createdAt = linkedAccount.createdAt {
+        if let createdAt {
             let createdAtDate = Date(timeIntervalSince1970: TimeInterval(createdAt / 1000))
             verifiedByString.append(NSAttributedString(
                 string: "\n" + L.Profile.LinkedAccountCreatedAt.localization,
@@ -114,7 +143,7 @@ class VerifiedInformationControlCollapsible: ExpandableControl {
                 attributes: AttributedStringHelper.attributes(font: .sourceSansProBold(size: 12), color: .grayGhost, lineSpacing: 6)
             ))
         }
-        if let expiresAt = linkedAccount.expiresAt {
+        if let expiresAt {
             let expiresAtDate = Date(timeIntervalSince1970: TimeInterval(expiresAt / 1000))
             verifiedByString.append(NSAttributedString(
                 string: "\n" + L.Profile.LinkedAccountValidUntil.localization,

--- a/EduID/Types/ScreenType.swift
+++ b/EduID/Types/ScreenType.swift
@@ -46,7 +46,8 @@ enum ScreenType: Int, CaseIterable {
     case confirmDeleteTokensScreen
     
     case verifyIdentityScreen
-    case selectYourBank
+    case selectYourBankScreen
+    case linkingSuccessScreen
     
     // security screens
     case securityOverviewScreen

--- a/EduID/Utilities/Constants.swift
+++ b/EduID/Utilities/Constants.swift
@@ -39,6 +39,7 @@ enum Constants {
         static let emailUpdateUrl = "emailUpdateUrl"
         static let passwordChangeUrl = "passwordChangeUrl"
         static let linkedAccountEmail = "linkedAccountEmail"
+        static let linkedAccountInstitution = "linkedAccountInstitution"
     }
     
     enum RegistrationCheck {

--- a/EduID/localizations.yaml
+++ b/EduID/localizations.yaml
@@ -3943,5 +3943,33 @@ SHARED:
         COPY:
           en: another method
           nl: andere methode
+  LinkingSuccess:
+    Title:
+      COPY:
+        en: "Your personal info 🎉"
+        nl: "Jouw persoonlijk informatie 🎉"
+    Subtitle:
+      COPY:
+        en: "The following information has been added to your eduID."
+        nl: ""
+    SubtitlePreferInstitution:
+      COPY:
+       en: "Do you want to use the following information to be the default information shared with applications?"
+       nl: "Wil je de volgende informatie, gebruiken als standaardinformatie om met diensten te delen?"
+    Button:
+      Continue:
+        COPY:
+          en: "Continue"
+          nl: "Ga door"
+      YesPlease:
+        COPY:
+          en: "Yes, please"
+          nl: "Ja, graag"
+      NoThanks:
+        COPY:
+          en: "No, thanks"
+          nl: "Nee, bedankt"
+    
+    
     
     

--- a/EduID/localizations.yaml
+++ b/EduID/localizations.yaml
@@ -3951,7 +3951,7 @@ SHARED:
     Subtitle:
       COPY:
         en: "The following information has been added to your eduID."
-        nl: ""
+        nl: "De volgende informatie is toegevoegd aan jouw eduID account."
     SubtitlePreferInstitution:
       COPY:
        en: "Do you want to use the following information to be the default information shared with applications?"
@@ -3969,7 +3969,3 @@ SHARED:
         COPY:
           en: "No, thanks"
           nl: "Nee, bedankt"
-    
-    
-    
-    

--- a/eduID.xcodeproj/project.pbxproj
+++ b/eduID.xcodeproj/project.pbxproj
@@ -291,6 +291,8 @@
 		4FC37C2A2A3C47A80036A94C /* PasswordResetLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC37C292A3C47A80036A94C /* PasswordResetLinkViewModel.swift */; };
 		4FC37C2C2A3C47F60036A94C /* PasswordResetLinkViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC37C2B2A3C47F60036A94C /* PasswordResetLinkViewController.swift */; };
 		4FDBF7532BC0414900371599 /* UpdateLinkedAccountRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FDBF7522BC0414900371599 /* UpdateLinkedAccountRequest.swift */; };
+		4FE5191A2CB7DEAC00F7F297 /* LinkingSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE519192CB7DEA800F7F297 /* LinkingSuccessViewController.swift */; };
+		4FE5191C2CB7DEC900F7F297 /* LinkingSuccessViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FE5191B2CB7DEC600F7F297 /* LinkingSuccessViewModel.swift */; };
 		4FEBF53E2A38A1F9004BF3C8 /* NameUpdatedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBF53D2A38A1F9004BF3C8 /* NameUpdatedViewController.swift */; };
 		4FEBF5402A38A22E004BF3C8 /* NameUpdatedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FEBF53F2A38A22E004BF3C8 /* NameUpdatedViewModel.swift */; };
 		4FF5679F2A31D32E00616341 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FF5675A2A31D32E00616341 /* HomeViewController.swift */; };
@@ -851,6 +853,8 @@
 		4FC37C292A3C47A80036A94C /* PasswordResetLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordResetLinkViewModel.swift; sourceTree = "<group>"; };
 		4FC37C2B2A3C47F60036A94C /* PasswordResetLinkViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordResetLinkViewController.swift; sourceTree = "<group>"; };
 		4FDBF7522BC0414900371599 /* UpdateLinkedAccountRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UpdateLinkedAccountRequest.swift; sourceTree = "<group>"; };
+		4FE519192CB7DEA800F7F297 /* LinkingSuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkingSuccessViewController.swift; sourceTree = "<group>"; };
+		4FE5191B2CB7DEC600F7F297 /* LinkingSuccessViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkingSuccessViewModel.swift; sourceTree = "<group>"; };
 		4FEBF53D2A38A1F9004BF3C8 /* NameUpdatedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameUpdatedViewController.swift; sourceTree = "<group>"; };
 		4FEBF53F2A38A22E004BF3C8 /* NameUpdatedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameUpdatedViewModel.swift; sourceTree = "<group>"; };
 		4FF5675A2A31D32E00616341 /* HomeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -1138,6 +1142,7 @@
 		4F4A3D612CAAAC680007FCE6 /* VerifyIdentity */ = {
 			isa = PBXGroup;
 			children = (
+				4FE519182CB7DEA100F7F297 /* LinkingSuccess */,
 				4F4A3D962CAAEC1E0007FCE6 /* SelectYourBank */,
 				4F4A3D642CAAD14C0007FCE6 /* VerifyIdentityControl.swift */,
 				4F6FB2782CAD8CF7005DF803 /* VerifyIdentityViewModel.swift */,
@@ -1723,6 +1728,15 @@
 			path = PasswordResetLink;
 			sourceTree = "<group>";
 		};
+		4FE519182CB7DEA100F7F297 /* LinkingSuccess */ = {
+			isa = PBXGroup;
+			children = (
+				4FE5191B2CB7DEC600F7F297 /* LinkingSuccessViewModel.swift */,
+				4FE519192CB7DEA800F7F297 /* LinkingSuccessViewController.swift */,
+			);
+			path = LinkingSuccess;
+			sourceTree = "<group>";
+		};
 		4FEBF53C2A38A1C0004BF3C8 /* NameUpdated */ = {
 			isa = PBXGroup;
 			children = (
@@ -2260,6 +2274,7 @@
 				4FF567B22A31D32E00616341 /* ActivityViewControllerDelegate.swift in Sources */,
 				4FF567A22A31D32E00616341 /* PersonalInfoViewModel.swift in Sources */,
 				4F909EC42A31CDDC00FC1506 /* BasicStackView.swift in Sources */,
+				4FE5191C2CB7DEC900F7F297 /* LinkingSuccessViewModel.swift in Sources */,
 				4F6560742B6BC3CB004A303D /* InfoViewController.swift in Sources */,
 				4F9D27312A33395C00F5A6ED /* Localizable.swift in Sources */,
 				4F909EBC2A31CDDC00FC1506 /* BaseViewController.swift in Sources */,
@@ -2356,6 +2371,7 @@
 				4FF567C52A31D32E00616341 /* PinViewModel.swift in Sources */,
 				4F909EC12A31CDDC00FC1506 /* InstitutionView.swift in Sources */,
 				4FF567C72A31D32E00616341 /* CreateEduIDCoordinatorDelegate.swift in Sources */,
+				4FE5191A2CB7DEAC00F7F297 /* LinkingSuccessViewController.swift in Sources */,
 				4FA824662B06478E00B0D802 /* DeleteKeyConfirmationViewController.swift in Sources */,
 				4FF567BC2A31D32E00616341 /* ScanViewController.swift in Sources */,
 				4F909EC52A31CDDC00FC1506 /* ActionableControlWithBodyAndTitle.swift in Sources */,

--- a/eduID.xcodeproj/project.pbxproj
+++ b/eduID.xcodeproj/project.pbxproj
@@ -230,61 +230,6 @@
 		4FB51EF42AF3EA5600069B13 /* OneTimeCodeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB51EF32AF3EA5600069B13 /* OneTimeCodeViewController.swift */; };
 		4FB7DB582C5BCC46007CD6E7 /* Tiqr in Frameworks */ = {isa = PBXBuildFile; productRef = 4FB7DB572C5BCC46007CD6E7 /* Tiqr */; };
 		4FB7DB5A2C5BCC4E007CD6E7 /* Tiqr in Frameworks */ = {isa = PBXBuildFile; productRef = 4FB7DB592C5BCC4E007CD6E7 /* Tiqr */; };
-		4FB7FE242CAC23010063ABC3 /* DeleteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF22CAC23010063ABC3 /* DeleteService.swift */; };
-		4FB7FE252CAC23010063ABC3 /* PhoneVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE022CAC23010063ABC3 /* PhoneVerification.swift */; };
-		4FB7FE262CAC23010063ABC3 /* EduIDInstitutionPseudonym.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF52CAC23010063ABC3 /* EduIDInstitutionPseudonym.swift */; };
-		4FB7FE272CAC23010063ABC3 /* AccountLinkerControllerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDE92CAC23010063ABC3 /* AccountLinkerControllerAPI.swift */; };
-		4FB7FE282CAC23010063ABC3 /* OpenISO8601DateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE1E2CAC23010063ABC3 /* OpenISO8601DateFormatter.swift */; };
-		4FB7FE292CAC23010063ABC3 /* StatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE092CAC23010063ABC3 /* StatusResponse.swift */; };
-		4FB7FE2A2CAC23010063ABC3 /* APIs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE172CAC23010063ABC3 /* APIs.swift */; };
-		4FB7FE2B2CAC23010063ABC3 /* VerifyPhoneCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE142CAC23010063ABC3 /* VerifyPhoneCode.swift */; };
-		4FB7FE2C2CAC23010063ABC3 /* StartEnrollment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE082CAC23010063ABC3 /* StartEnrollment.swift */; };
-		4FB7FE2D2CAC23010063ABC3 /* UpdateEmailRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE0C2CAC23010063ABC3 /* UpdateEmailRequest.swift */; };
-		4FB7FE2E2CAC23010063ABC3 /* PollAuthenticationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE032CAC23010063ABC3 /* PollAuthenticationResult.swift */; };
-		4FB7FE2F2CAC23010063ABC3 /* IdentityProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDFD2CAC23010063ABC3 /* IdentityProvider.swift */; };
-		4FB7FE302CAC23010063ABC3 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE112CAC23010063ABC3 /* User.swift */; };
-		4FB7FE312CAC23010063ABC3 /* UpdateExternalEduID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE0D2CAC23010063ABC3 /* UpdateExternalEduID.swift */; };
-		4FB7FE322CAC23010063ABC3 /* UpdateUserSecurityRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE102CAC23010063ABC3 /* UpdateUserSecurityRequest.swift */; };
-		4FB7FE332CAC23010063ABC3 /* ManualResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDFF2CAC23010063ABC3 /* ManualResponse.swift */; };
-		4FB7FE342CAC23010063ABC3 /* DeactivateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF12CAC23010063ABC3 /* DeactivateRequest.swift */; };
-		4FB7FE352CAC23010063ABC3 /* LinkedAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDFE2CAC23010063ABC3 /* LinkedAccount.swift */; };
-		4FB7FE362CAC23010063ABC3 /* SynchronizedDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE1F2CAC23010063ABC3 /* SynchronizedDictionary.swift */; };
-		4FB7FE372CAC23010063ABC3 /* TiqrControllerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDEC2CAC23010063ABC3 /* TiqrControllerAPI.swift */; };
-		4FB7FE382CAC23010063ABC3 /* RemoteCreationControllerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDEB2CAC23010063ABC3 /* RemoteCreationControllerAPI.swift */; };
-		4FB7FE392CAC23010063ABC3 /* URLSessionImplementations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE202CAC23010063ABC3 /* URLSessionImplementations.swift */; };
-		4FB7FE3A2CAC23010063ABC3 /* FinishEnrollment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDFB2CAC23010063ABC3 /* FinishEnrollment.swift */; };
-		4FB7FE3B2CAC23010063ABC3 /* InviteControllerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDEA2CAC23010063ABC3 /* InviteControllerAPI.swift */; };
-		4FB7FE3C2CAC23010063ABC3 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE212CAC23010063ABC3 /* Validation.swift */; };
-		4FB7FE3D2CAC23010063ABC3 /* APIHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE162CAC23010063ABC3 /* APIHelper.swift */; };
-		4FB7FE3E2CAC23010063ABC3 /* TokenRepresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE0B2CAC23010063ABC3 /* TokenRepresentation.swift */; };
-		4FB7FE3F2CAC23010063ABC3 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE1A2CAC23010063ABC3 /* Extensions.swift */; };
-		4FB7FE402CAC23010063ABC3 /* StartAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE072CAC23010063ABC3 /* StartAuthentication.swift */; };
-		4FB7FE412CAC23010063ABC3 /* PublicKeyCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE042CAC23010063ABC3 /* PublicKeyCredentials.swift */; };
-		4FB7FE422CAC23010063ABC3 /* UpdateUserNameRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE0F2CAC23010063ABC3 /* UpdateUserNameRequest.swift */; };
-		4FB7FE432CAC23010063ABC3 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE192CAC23010063ABC3 /* Configuration.swift */; };
-		4FB7FE442CAC23010063ABC3 /* UserControllerAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDED2CAC23010063ABC3 /* UserControllerAPI.swift */; };
-		4FB7FE452CAC23010063ABC3 /* Scope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE052CAC23010063ABC3 /* Scope.swift */; };
-		4FB7FE462CAC23010063ABC3 /* JSONDataEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE1B2CAC23010063ABC3 /* JSONDataEncoding.swift */; };
-		4FB7FE472CAC23010063ABC3 /* EnrollmentVerificationKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF92CAC23010063ABC3 /* EnrollmentVerificationKey.swift */; };
-		4FB7FE482CAC23010063ABC3 /* GeneratedBackupCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDFC2CAC23010063ABC3 /* GeneratedBackupCode.swift */; };
-		4FB7FE492CAC23010063ABC3 /* EduID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF42CAC23010063ABC3 /* EduID.swift */; };
-		4FB7FE4A2CAC23010063ABC3 /* ServiceProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE062CAC23010063ABC3 /* ServiceProvider.swift */; };
-		4FB7FE4B2CAC23010063ABC3 /* NewExternalEduID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE002CAC23010063ABC3 /* NewExternalEduID.swift */; };
-		4FB7FE4C2CAC23010063ABC3 /* Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE1D2CAC23010063ABC3 /* Models.swift */; };
-		4FB7FE4D2CAC23010063ABC3 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE0A2CAC23010063ABC3 /* Token.swift */; };
-		4FB7FE4E2CAC23010063ABC3 /* DeleteServiceTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF32CAC23010063ABC3 /* DeleteServiceTokens.swift */; };
-		4FB7FE4F2CAC23010063ABC3 /* AuthorizationURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDEF2CAC23010063ABC3 /* AuthorizationURL.swift */; };
-		4FB7FE502CAC23010063ABC3 /* VerifyIssuer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE132CAC23010063ABC3 /* VerifyIssuer.swift */; };
-		4FB7FE512CAC23010063ABC3 /* UserResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE122CAC23010063ABC3 /* UserResponse.swift */; };
-		4FB7FE522CAC23010063ABC3 /* UpdateLinkedAccountRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE0E2CAC23010063ABC3 /* UpdateLinkedAccountRequest.swift */; };
-		4FB7FE532CAC23010063ABC3 /* ExternalLinkedAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDFA2CAC23010063ABC3 /* ExternalLinkedAccount.swift */; };
-		4FB7FE542CAC23010063ABC3 /* EduIDValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF72CAC23010063ABC3 /* EduIDValue.swift */; };
-		4FB7FE552CAC23010063ABC3 /* EduIDProvision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF62CAC23010063ABC3 /* EduIDProvision.swift */; };
-		4FB7FE562CAC23010063ABC3 /* PhoneCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE012CAC23010063ABC3 /* PhoneCode.swift */; };
-		4FB7FE572CAC23010063ABC3 /* EmailExistsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF82CAC23010063ABC3 /* EmailExistsResponse.swift */; };
-		4FB7FE582CAC23010063ABC3 /* JSONEncodingHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE1C2CAC23010063ABC3 /* JSONEncodingHelper.swift */; };
-		4FB7FE592CAC23010063ABC3 /* CreateAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FDF02CAC23010063ABC3 /* CreateAccount.swift */; };
-		4FB7FE5A2CAC23010063ABC3 /* CodableHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB7FE182CAC23010063ABC3 /* CodableHelper.swift */; };
 		4FC350AF2A373AA7003CB086 /* EmailEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC350AE2A373AA7003CB086 /* EmailEditorViewController.swift */; };
 		4FC350B22A373B1B003CB086 /* EmailEditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC350B12A373B1B003CB086 /* EmailEditorViewModel.swift */; };
 		4FC37C252A3C27550036A94C /* SecurityOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FC37C242A3C27550036A94C /* SecurityOverviewViewModel.swift */; };
@@ -792,61 +737,6 @@
 		4FADBCE22A4094DC002311E4 /* TwoFactorKeyControlCollapsible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwoFactorKeyControlCollapsible.swift; sourceTree = "<group>"; };
 		4FB51EF32AF3EA5600069B13 /* OneTimeCodeViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OneTimeCodeViewController.swift; sourceTree = "<group>"; };
 		4FB7DB552C5BC0E5007CD6E7 /* Notifications.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Notifications.entitlements; sourceTree = "<group>"; };
-		4FB7FDE92CAC23010063ABC3 /* AccountLinkerControllerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLinkerControllerAPI.swift; sourceTree = "<group>"; };
-		4FB7FDEA2CAC23010063ABC3 /* InviteControllerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteControllerAPI.swift; sourceTree = "<group>"; };
-		4FB7FDEB2CAC23010063ABC3 /* RemoteCreationControllerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCreationControllerAPI.swift; sourceTree = "<group>"; };
-		4FB7FDEC2CAC23010063ABC3 /* TiqrControllerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiqrControllerAPI.swift; sourceTree = "<group>"; };
-		4FB7FDED2CAC23010063ABC3 /* UserControllerAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserControllerAPI.swift; sourceTree = "<group>"; };
-		4FB7FDEF2CAC23010063ABC3 /* AuthorizationURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizationURL.swift; sourceTree = "<group>"; };
-		4FB7FDF02CAC23010063ABC3 /* CreateAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccount.swift; sourceTree = "<group>"; };
-		4FB7FDF12CAC23010063ABC3 /* DeactivateRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeactivateRequest.swift; sourceTree = "<group>"; };
-		4FB7FDF22CAC23010063ABC3 /* DeleteService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteService.swift; sourceTree = "<group>"; };
-		4FB7FDF32CAC23010063ABC3 /* DeleteServiceTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteServiceTokens.swift; sourceTree = "<group>"; };
-		4FB7FDF42CAC23010063ABC3 /* EduID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EduID.swift; sourceTree = "<group>"; };
-		4FB7FDF52CAC23010063ABC3 /* EduIDInstitutionPseudonym.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EduIDInstitutionPseudonym.swift; sourceTree = "<group>"; };
-		4FB7FDF62CAC23010063ABC3 /* EduIDProvision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EduIDProvision.swift; sourceTree = "<group>"; };
-		4FB7FDF72CAC23010063ABC3 /* EduIDValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EduIDValue.swift; sourceTree = "<group>"; };
-		4FB7FDF82CAC23010063ABC3 /* EmailExistsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailExistsResponse.swift; sourceTree = "<group>"; };
-		4FB7FDF92CAC23010063ABC3 /* EnrollmentVerificationKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrollmentVerificationKey.swift; sourceTree = "<group>"; };
-		4FB7FDFA2CAC23010063ABC3 /* ExternalLinkedAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalLinkedAccount.swift; sourceTree = "<group>"; };
-		4FB7FDFB2CAC23010063ABC3 /* FinishEnrollment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinishEnrollment.swift; sourceTree = "<group>"; };
-		4FB7FDFC2CAC23010063ABC3 /* GeneratedBackupCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedBackupCode.swift; sourceTree = "<group>"; };
-		4FB7FDFD2CAC23010063ABC3 /* IdentityProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityProvider.swift; sourceTree = "<group>"; };
-		4FB7FDFE2CAC23010063ABC3 /* LinkedAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedAccount.swift; sourceTree = "<group>"; };
-		4FB7FDFF2CAC23010063ABC3 /* ManualResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualResponse.swift; sourceTree = "<group>"; };
-		4FB7FE002CAC23010063ABC3 /* NewExternalEduID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewExternalEduID.swift; sourceTree = "<group>"; };
-		4FB7FE012CAC23010063ABC3 /* PhoneCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneCode.swift; sourceTree = "<group>"; };
-		4FB7FE022CAC23010063ABC3 /* PhoneVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneVerification.swift; sourceTree = "<group>"; };
-		4FB7FE032CAC23010063ABC3 /* PollAuthenticationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PollAuthenticationResult.swift; sourceTree = "<group>"; };
-		4FB7FE042CAC23010063ABC3 /* PublicKeyCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicKeyCredentials.swift; sourceTree = "<group>"; };
-		4FB7FE052CAC23010063ABC3 /* Scope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scope.swift; sourceTree = "<group>"; };
-		4FB7FE062CAC23010063ABC3 /* ServiceProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceProvider.swift; sourceTree = "<group>"; };
-		4FB7FE072CAC23010063ABC3 /* StartAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartAuthentication.swift; sourceTree = "<group>"; };
-		4FB7FE082CAC23010063ABC3 /* StartEnrollment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartEnrollment.swift; sourceTree = "<group>"; };
-		4FB7FE092CAC23010063ABC3 /* StatusResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusResponse.swift; sourceTree = "<group>"; };
-		4FB7FE0A2CAC23010063ABC3 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
-		4FB7FE0B2CAC23010063ABC3 /* TokenRepresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenRepresentation.swift; sourceTree = "<group>"; };
-		4FB7FE0C2CAC23010063ABC3 /* UpdateEmailRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateEmailRequest.swift; sourceTree = "<group>"; };
-		4FB7FE0D2CAC23010063ABC3 /* UpdateExternalEduID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateExternalEduID.swift; sourceTree = "<group>"; };
-		4FB7FE0E2CAC23010063ABC3 /* UpdateLinkedAccountRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateLinkedAccountRequest.swift; sourceTree = "<group>"; };
-		4FB7FE0F2CAC23010063ABC3 /* UpdateUserNameRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserNameRequest.swift; sourceTree = "<group>"; };
-		4FB7FE102CAC23010063ABC3 /* UpdateUserSecurityRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateUserSecurityRequest.swift; sourceTree = "<group>"; };
-		4FB7FE112CAC23010063ABC3 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
-		4FB7FE122CAC23010063ABC3 /* UserResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponse.swift; sourceTree = "<group>"; };
-		4FB7FE132CAC23010063ABC3 /* VerifyIssuer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyIssuer.swift; sourceTree = "<group>"; };
-		4FB7FE142CAC23010063ABC3 /* VerifyPhoneCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerifyPhoneCode.swift; sourceTree = "<group>"; };
-		4FB7FE162CAC23010063ABC3 /* APIHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIHelper.swift; sourceTree = "<group>"; };
-		4FB7FE172CAC23010063ABC3 /* APIs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIs.swift; sourceTree = "<group>"; };
-		4FB7FE182CAC23010063ABC3 /* CodableHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableHelper.swift; sourceTree = "<group>"; };
-		4FB7FE192CAC23010063ABC3 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
-		4FB7FE1A2CAC23010063ABC3 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
-		4FB7FE1B2CAC23010063ABC3 /* JSONDataEncoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDataEncoding.swift; sourceTree = "<group>"; };
-		4FB7FE1C2CAC23010063ABC3 /* JSONEncodingHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONEncodingHelper.swift; sourceTree = "<group>"; };
-		4FB7FE1D2CAC23010063ABC3 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
-		4FB7FE1E2CAC23010063ABC3 /* OpenISO8601DateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenISO8601DateFormatter.swift; sourceTree = "<group>"; };
-		4FB7FE1F2CAC23010063ABC3 /* SynchronizedDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynchronizedDictionary.swift; sourceTree = "<group>"; };
-		4FB7FE202CAC23010063ABC3 /* URLSessionImplementations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionImplementations.swift; sourceTree = "<group>"; };
-		4FB7FE212CAC23010063ABC3 /* Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
 		4FC350AE2A373AA7003CB086 /* EmailEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailEditorViewController.swift; sourceTree = "<group>"; };
 		4FC350B12A373B1B003CB086 /* EmailEditorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailEditorViewModel.swift; sourceTree = "<group>"; };
 		4FC37C242A3C27550036A94C /* SecurityOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecurityOverviewViewModel.swift; sourceTree = "<group>"; };
@@ -1615,92 +1505,6 @@
 			path = TwoFactorKeys;
 			sourceTree = "<group>";
 		};
-		4FB7FDEE2CAC23010063ABC3 /* APIs */ = {
-			isa = PBXGroup;
-			children = (
-				4FB7FDE92CAC23010063ABC3 /* AccountLinkerControllerAPI.swift */,
-				4FB7FDEA2CAC23010063ABC3 /* InviteControllerAPI.swift */,
-				4FB7FDEB2CAC23010063ABC3 /* RemoteCreationControllerAPI.swift */,
-				4FB7FDEC2CAC23010063ABC3 /* TiqrControllerAPI.swift */,
-				4FB7FDED2CAC23010063ABC3 /* UserControllerAPI.swift */,
-			);
-			path = APIs;
-			sourceTree = "<group>";
-		};
-		4FB7FE152CAC23010063ABC3 /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				4FB7FDEF2CAC23010063ABC3 /* AuthorizationURL.swift */,
-				4FB7FDF02CAC23010063ABC3 /* CreateAccount.swift */,
-				4FB7FDF12CAC23010063ABC3 /* DeactivateRequest.swift */,
-				4FB7FDF22CAC23010063ABC3 /* DeleteService.swift */,
-				4FB7FDF32CAC23010063ABC3 /* DeleteServiceTokens.swift */,
-				4FB7FDF42CAC23010063ABC3 /* EduID.swift */,
-				4FB7FDF52CAC23010063ABC3 /* EduIDInstitutionPseudonym.swift */,
-				4FB7FDF62CAC23010063ABC3 /* EduIDProvision.swift */,
-				4FB7FDF72CAC23010063ABC3 /* EduIDValue.swift */,
-				4FB7FDF82CAC23010063ABC3 /* EmailExistsResponse.swift */,
-				4FB7FDF92CAC23010063ABC3 /* EnrollmentVerificationKey.swift */,
-				4FB7FDFA2CAC23010063ABC3 /* ExternalLinkedAccount.swift */,
-				4FB7FDFB2CAC23010063ABC3 /* FinishEnrollment.swift */,
-				4FB7FDFC2CAC23010063ABC3 /* GeneratedBackupCode.swift */,
-				4FB7FDFD2CAC23010063ABC3 /* IdentityProvider.swift */,
-				4FB7FDFE2CAC23010063ABC3 /* LinkedAccount.swift */,
-				4FB7FDFF2CAC23010063ABC3 /* ManualResponse.swift */,
-				4FB7FE002CAC23010063ABC3 /* NewExternalEduID.swift */,
-				4FB7FE012CAC23010063ABC3 /* PhoneCode.swift */,
-				4FB7FE022CAC23010063ABC3 /* PhoneVerification.swift */,
-				4FB7FE032CAC23010063ABC3 /* PollAuthenticationResult.swift */,
-				4FB7FE042CAC23010063ABC3 /* PublicKeyCredentials.swift */,
-				4FB7FE052CAC23010063ABC3 /* Scope.swift */,
-				4FB7FE062CAC23010063ABC3 /* ServiceProvider.swift */,
-				4FB7FE072CAC23010063ABC3 /* StartAuthentication.swift */,
-				4FB7FE082CAC23010063ABC3 /* StartEnrollment.swift */,
-				4FB7FE092CAC23010063ABC3 /* StatusResponse.swift */,
-				4FB7FE0A2CAC23010063ABC3 /* Token.swift */,
-				4FB7FE0B2CAC23010063ABC3 /* TokenRepresentation.swift */,
-				4FB7FE0C2CAC23010063ABC3 /* UpdateEmailRequest.swift */,
-				4FB7FE0D2CAC23010063ABC3 /* UpdateExternalEduID.swift */,
-				4FB7FE0E2CAC23010063ABC3 /* UpdateLinkedAccountRequest.swift */,
-				4FB7FE0F2CAC23010063ABC3 /* UpdateUserNameRequest.swift */,
-				4FB7FE102CAC23010063ABC3 /* UpdateUserSecurityRequest.swift */,
-				4FB7FE112CAC23010063ABC3 /* User.swift */,
-				4FB7FE122CAC23010063ABC3 /* UserResponse.swift */,
-				4FB7FE132CAC23010063ABC3 /* VerifyIssuer.swift */,
-				4FB7FE142CAC23010063ABC3 /* VerifyPhoneCode.swift */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		4FB7FE222CAC23010063ABC3 /* OpenAPIs */ = {
-			isa = PBXGroup;
-			children = (
-				4FB7FDEE2CAC23010063ABC3 /* APIs */,
-				4FB7FE152CAC23010063ABC3 /* Models */,
-				4FB7FE162CAC23010063ABC3 /* APIHelper.swift */,
-				4FB7FE172CAC23010063ABC3 /* APIs.swift */,
-				4FB7FE182CAC23010063ABC3 /* CodableHelper.swift */,
-				4FB7FE192CAC23010063ABC3 /* Configuration.swift */,
-				4FB7FE1A2CAC23010063ABC3 /* Extensions.swift */,
-				4FB7FE1B2CAC23010063ABC3 /* JSONDataEncoding.swift */,
-				4FB7FE1C2CAC23010063ABC3 /* JSONEncodingHelper.swift */,
-				4FB7FE1D2CAC23010063ABC3 /* Models.swift */,
-				4FB7FE1E2CAC23010063ABC3 /* OpenISO8601DateFormatter.swift */,
-				4FB7FE1F2CAC23010063ABC3 /* SynchronizedDictionary.swift */,
-				4FB7FE202CAC23010063ABC3 /* URLSessionImplementations.swift */,
-				4FB7FE212CAC23010063ABC3 /* Validation.swift */,
-			);
-			path = OpenAPIs;
-			sourceTree = "<group>";
-		};
-		4FB7FE232CAC23010063ABC3 /* Classes */ = {
-			isa = PBXGroup;
-			children = (
-				4FB7FE222CAC23010063ABC3 /* OpenAPIs */,
-			);
-			path = Classes;
-			sourceTree = "<group>";
-		};
 		4FC350B02A373B05003CB086 /* EmailEditor */ = {
 			isa = PBXGroup;
 			children = (
@@ -1909,7 +1713,6 @@
 			isa = PBXGroup;
 			children = (
 				4F1F12BE2CAD611F002DA23A /* Classes */,
-				4FB7FE232CAC23010063ABC3 /* Classes */,
 				4F8E507B2CAC11130018D05E /* Classes */,
 				4F909F1E2A31D07500FC1506 /* generate command.md */,
 				4F909F1F2A31D07500FC1506 /* docs */,
@@ -2483,13 +2286,6 @@
 				4F8E50A22CAC11130018D05E /* APIs.swift in Sources */,
 				4F8E50A32CAC11130018D05E /* UpdateUserSecurityRequest.swift in Sources */,
 				4F8E50A42CAC11130018D05E /* UserControllerAPI.swift in Sources */,
-				4FB7FE242CAC23010063ABC3 /* DeleteService.swift in Sources */,
-				4FB7FE252CAC23010063ABC3 /* PhoneVerification.swift in Sources */,
-				4FB7FE262CAC23010063ABC3 /* EduIDInstitutionPseudonym.swift in Sources */,
-				4FB7FE272CAC23010063ABC3 /* AccountLinkerControllerAPI.swift in Sources */,
-				4FB7FE282CAC23010063ABC3 /* OpenISO8601DateFormatter.swift in Sources */,
-				4FB7FE292CAC23010063ABC3 /* StatusResponse.swift in Sources */,
-				4FB7FE2A2CAC23010063ABC3 /* APIs.swift in Sources */,
 				4F1F12BF2CAD611F002DA23A /* APIHelper.swift in Sources */,
 				4F1F12C02CAD611F002DA23A /* JSONDataEncoding.swift in Sources */,
 				4F1F12C12CAD611F002DA23A /* UpdateLinkedAccountRequest.swift in Sources */,
@@ -2545,54 +2341,6 @@
 				4F1F12F32CAD611F002DA23A /* Scope.swift in Sources */,
 				4F1F12F42CAD611F002DA23A /* Token.swift in Sources */,
 				4F1F12F52CAD611F002DA23A /* UpdateUserNameRequest.swift in Sources */,
-				4FB7FE2B2CAC23010063ABC3 /* VerifyPhoneCode.swift in Sources */,
-				4FB7FE2C2CAC23010063ABC3 /* StartEnrollment.swift in Sources */,
-				4FB7FE2D2CAC23010063ABC3 /* UpdateEmailRequest.swift in Sources */,
-				4FB7FE2E2CAC23010063ABC3 /* PollAuthenticationResult.swift in Sources */,
-				4FB7FE2F2CAC23010063ABC3 /* IdentityProvider.swift in Sources */,
-				4FB7FE302CAC23010063ABC3 /* User.swift in Sources */,
-				4FB7FE312CAC23010063ABC3 /* UpdateExternalEduID.swift in Sources */,
-				4FB7FE322CAC23010063ABC3 /* UpdateUserSecurityRequest.swift in Sources */,
-				4FB7FE332CAC23010063ABC3 /* ManualResponse.swift in Sources */,
-				4FB7FE342CAC23010063ABC3 /* DeactivateRequest.swift in Sources */,
-				4FB7FE352CAC23010063ABC3 /* LinkedAccount.swift in Sources */,
-				4FB7FE362CAC23010063ABC3 /* SynchronizedDictionary.swift in Sources */,
-				4FB7FE372CAC23010063ABC3 /* TiqrControllerAPI.swift in Sources */,
-				4FB7FE382CAC23010063ABC3 /* RemoteCreationControllerAPI.swift in Sources */,
-				4FB7FE392CAC23010063ABC3 /* URLSessionImplementations.swift in Sources */,
-				4FB7FE3A2CAC23010063ABC3 /* FinishEnrollment.swift in Sources */,
-				4FB7FE3B2CAC23010063ABC3 /* InviteControllerAPI.swift in Sources */,
-				4FB7FE3C2CAC23010063ABC3 /* Validation.swift in Sources */,
-				4FB7FE3D2CAC23010063ABC3 /* APIHelper.swift in Sources */,
-				4FB7FE3E2CAC23010063ABC3 /* TokenRepresentation.swift in Sources */,
-				4FB7FE3F2CAC23010063ABC3 /* Extensions.swift in Sources */,
-				4FB7FE402CAC23010063ABC3 /* StartAuthentication.swift in Sources */,
-				4FB7FE412CAC23010063ABC3 /* PublicKeyCredentials.swift in Sources */,
-				4FB7FE422CAC23010063ABC3 /* UpdateUserNameRequest.swift in Sources */,
-				4FB7FE432CAC23010063ABC3 /* Configuration.swift in Sources */,
-				4FB7FE442CAC23010063ABC3 /* UserControllerAPI.swift in Sources */,
-				4FB7FE452CAC23010063ABC3 /* Scope.swift in Sources */,
-				4FB7FE462CAC23010063ABC3 /* JSONDataEncoding.swift in Sources */,
-				4FB7FE472CAC23010063ABC3 /* EnrollmentVerificationKey.swift in Sources */,
-				4FB7FE482CAC23010063ABC3 /* GeneratedBackupCode.swift in Sources */,
-				4FB7FE492CAC23010063ABC3 /* EduID.swift in Sources */,
-				4FB7FE4A2CAC23010063ABC3 /* ServiceProvider.swift in Sources */,
-				4FB7FE4B2CAC23010063ABC3 /* NewExternalEduID.swift in Sources */,
-				4FB7FE4C2CAC23010063ABC3 /* Models.swift in Sources */,
-				4FB7FE4D2CAC23010063ABC3 /* Token.swift in Sources */,
-				4FB7FE4E2CAC23010063ABC3 /* DeleteServiceTokens.swift in Sources */,
-				4FB7FE4F2CAC23010063ABC3 /* AuthorizationURL.swift in Sources */,
-				4FB7FE502CAC23010063ABC3 /* VerifyIssuer.swift in Sources */,
-				4FB7FE512CAC23010063ABC3 /* UserResponse.swift in Sources */,
-				4FB7FE522CAC23010063ABC3 /* UpdateLinkedAccountRequest.swift in Sources */,
-				4FB7FE532CAC23010063ABC3 /* ExternalLinkedAccount.swift in Sources */,
-				4FB7FE542CAC23010063ABC3 /* EduIDValue.swift in Sources */,
-				4FB7FE552CAC23010063ABC3 /* EduIDProvision.swift in Sources */,
-				4FB7FE562CAC23010063ABC3 /* PhoneCode.swift in Sources */,
-				4FB7FE572CAC23010063ABC3 /* EmailExistsResponse.swift in Sources */,
-				4FB7FE582CAC23010063ABC3 /* JSONEncodingHelper.swift in Sources */,
-				4FB7FE592CAC23010063ABC3 /* CreateAccount.swift in Sources */,
-				4FB7FE5A2CAC23010063ABC3 /* CodableHelper.swift in Sources */,
 				4F8E50A52CAC11130018D05E /* VerifyPhoneCode.swift in Sources */,
 				4F8E50A62CAC11130018D05E /* APIHelper.swift in Sources */,
 				4F8E50A72CAC11130018D05E /* Scope.swift in Sources */,

--- a/eduID/SceneDelegate.swift
+++ b/eduID/SceneDelegate.swift
@@ -78,7 +78,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
             return
         } else if (url.absoluteString.range(of: "account-linked") != nil) {
-            NotificationCenter.default.post(name: .didAddLinkedAccounts, object: nil)
+            let linkedAccountInstitution = url.queryParameters?["institution"] ?? ""
+            NotificationCenter.default.post(name: .didAddLinkedAccounts, object: nil, userInfo: [Constants.UserInfoKey.linkedAccountInstitution: linkedAccountInstitution])
         } else if url.absoluteString.range(of: "update-email") != nil {
             NotificationCenter.default.post(name: .didUpdateEmail, object: nil, userInfo: [Constants.UserInfoKey.emailUpdateUrl: url])
         } else if url.absoluteString.range(of: "add-password") != nil {


### PR DESCRIPTION
- Improved error handling by using our own custom error class, `EduIdError`
- Added the ability to remove linked external accounts
- The app now shows external linked accounts in the "Your verified information" screen
- Linking success screen basics (not fully working yet, comes in next PR)