### PR TITLE
TIQR-485: Login and registration via WebView

### DIFF
--- a/EduID/Flows/Activity/ActivityViewController.swift
+++ b/EduID/Flows/Activity/ActivityViewController.swift
@@ -19,7 +19,11 @@ class ActivityViewController: BaseViewController {
             alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .default) { _ in
                 alert.dismiss(animated: true) {
                     if eduidError.statusCode == 401 {
-                        AppAuthController.shared.authorize(viewController: self)
+                        guard let navigationController = self.navigationController else {
+                            assertionFailure("Navigation controller could not be found!")
+                            return
+                        }
+                        AppAuthController.shared.authorize(navigationController: navigationController)
                         self.dismiss(animated: false)
                         self.refreshDelegate?.requestScreenRefresh(for: .activity)
                     } else if eduidError.statusCode == -1 {

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDAddInstitutionViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDAddInstitutionViewController.swift
@@ -28,7 +28,11 @@ class CreateEduIDAddInstitutionViewController: CreateEduIDBaseViewController {
             alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .default) { _ in
                 alert.dismiss(animated: true) {
                     if eduidError.statusCode == 401 {
-                        AppAuthController.shared.authorize(viewController: self)
+                        guard let navigationController = self.navigationController else {
+                            assertionFailure("Navigation controller could not be found!")
+                            return
+                        }
+                        AppAuthController.shared.authorize(navigationController: navigationController)
                     } else if eduidError.statusCode == -1 {
                         self.dismiss(animated: true)
                     }

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDCreatedViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDCreatedViewController.swift
@@ -59,7 +59,11 @@ class CreateEduIDCreatedViewController: CreateEduIDBaseViewController {
     @objc
     func authorize() {
         continueButton.isUserInteractionEnabled = false
-        AppAuthController.shared.authorize(viewController: self)
+        guard let navigationController else {
+            assertionFailure("Navigation controller could not be found!")
+            return
+        }
+        AppAuthController.shared.authorize(navigationController: navigationController)
         showNextScreen()
     }
 

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDLandingPageViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDLandingPageViewController.swift
@@ -52,7 +52,7 @@ class CreateEduIDLandingPageViewController: CreateEduIDBaseViewController {
         scanQRButton.addTarget(self, action: #selector(showScanScreen), for: .touchUpInside)
         
         //the action for this button is on CreateEduIDBaseViewController superclass
-        noEduIDYetButton.addTarget(self, action: #selector(showNextScreen(_:)), for: .touchUpInside)
+        noEduIDYetButton.addTarget(self, action: #selector(noEduIdTapped), for: .touchUpInside)
         
         // - create the stackview
         stack = AnimatedVStackView(arrangedSubviews: [logo, posterLabel, imageView, lowerSpaceView, signInButton, scanQRButton])
@@ -95,6 +95,18 @@ class CreateEduIDLandingPageViewController: CreateEduIDBaseViewController {
     }
     
     @objc func signInTapped() {
-        AppAuthController.shared.authorize(viewController: self)
+        guard let navigationController else {
+            assertionFailure("Navigation controller could not be found!")
+            return
+        }
+        AppAuthController.shared.authorize(navigationController: navigationController, isRegistrationFlow: false)
+    }
+    
+    @objc func noEduIdTapped() {
+        guard let navigationController else {
+            assertionFailure("Navigation controller could not be found!")
+            return
+        }
+        AppAuthController.shared.authorize(navigationController: navigationController, isRegistrationFlow: true)
     }
 }

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDRegistrationCheckViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDRegistrationCheckViewController.swift
@@ -55,6 +55,17 @@ class CreateEduIDRegistrationCheckViewController: CreateEduIDBaseViewController 
                                           and: L.Security.Tiqr.AlreadyEnrolled.Description.localization, for: .deactivate)
                     } else {
                         self.showNextScreen()
+                        // Exclude this screen from the stack
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                            guard let self, let navigationController else {
+                                return
+                            }
+                            var viewControllers = navigationController.viewControllers
+                            if let currentIndex = viewControllers.firstIndex(of: self) {
+                                viewControllers.remove(at: currentIndex) // Remove the current view controller
+                            }
+                            navigationController.setViewControllers(viewControllers, animated: false)
+                        }
                     }
                 }
             }.store(in: &cancellable)

--- a/EduID/Flows/Home/HomeViewController.swift
+++ b/EduID/Flows/Home/HomeViewController.swift
@@ -177,7 +177,11 @@ class HomeViewController: UIViewController, ScreenWithScreenType {
     
     private func askForAuthorisationIfNeeded() -> Bool {
         if !AppAuthController.shared.isLoggedIn() {
-            AppAuthController.shared.authorize(viewController: self)
+            guard let navigationController else {
+                assertionFailure("Navigation controller could not be found!")
+                return false
+            }
+            AppAuthController.shared.authorize(navigationController: navigationController)
             return true
         }
         return false

--- a/EduID/Flows/PersonalInfo/PersonalInfoViewController.swift
+++ b/EduID/Flows/PersonalInfo/PersonalInfoViewController.swift
@@ -39,7 +39,11 @@ class PersonalInfoViewController: UIViewController, ScreenWithScreenType {
             alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .default) { _ in
                 alert.dismiss(animated: true) {
                     if eduidError.statusCode == 401 {
-                        AppAuthController.shared.authorize(viewController: self)
+                        guard let navigationController = self.navigationController else {
+                            assertionFailure("Navigation controller could not be found!")
+                            return
+                        }
+                        AppAuthController.shared.authorize(navigationController: navigationController)
                         self.dismiss(animated: false)
                         self.refreshDelegate?.requestScreenRefresh(for: .personalInfo)
                     } else if eduidError.statusCode == -1 {

--- a/EduID/Flows/Security/SecurityOverviewViewController.swift
+++ b/EduID/Flows/Security/SecurityOverviewViewController.swift
@@ -23,7 +23,11 @@ class SecurityOverviewViewController: UIViewController, ScreenWithScreenType {
             alert.addAction(UIAlertAction(title: L.PinAndBioMetrics.OKButton.localization, style: .default) { _ in
                 alert.dismiss(animated: true) {
                     if eduidError.statusCode == 401 {
-                        AppAuthController.shared.authorize(viewController: self)
+                        guard let navigationController = self.navigationController else {
+                            assertionFailure("Navigation controller could not be found!")
+                            return
+                        }
+                        AppAuthController.shared.authorize(navigationController: navigationController)
                         self.dismiss(animated: false)
                         self.refreshDelegate?.requestScreenRefresh(for: .security)
                     } else if eduidError.statusCode == -1 {

--- a/EduID/Flows/WebView/WebViewController.swift
+++ b/EduID/Flows/WebView/WebViewController.swift
@@ -1,0 +1,88 @@
+//
+//  WebViewController.swift
+//  eduID
+//
+//  Created by Dániel Zolnai on 2024. 11. 28..
+//
+import WebKit
+import TinyConstraints
+import NotificationCenter
+
+class WebViewController: BaseViewController {
+    
+    var startURL: URL!
+    var isRegistrationFlow = false
+    
+    private var webView: WKWebView!
+    
+    required init(startURL: URL) {
+        self.startURL = startURL
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @MainActor required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        screenType = .webView
+        
+        self.view.backgroundColor = .white
+        self.webView = WKWebView(frame: .zero)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(webView)
+        webView.edgesToSuperview(usingSafeArea: true)
+        webView.load(URLRequest(url: startURL))
+        webView.navigationDelegate = self
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(onMagicLinkOpened), name: .onMagicLinkOpened, object: nil)
+    }
+    
+    @objc
+    func onMagicLinkOpened(_ notification: NSNotification) {
+        guard let url = notification.userInfo?[Constants.UserInfoKey.magicLinkUrl] as? URL else {
+            assertionFailure("No magic link URL property sent in the notification!")
+            return
+        }
+        // Navigate to the URL in our browser
+        self.webView.load(URLRequest(url: url))
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: true)
+        let closeButton = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(dismissInfoScreen))
+        navigationItem.leftBarButtonItem = nil
+        navigationItem.rightBarButtonItem = closeButton
+    }
+    
+    @objc func dismissInfoScreen() {
+        _ = self.navigationController?.dismiss(animated: true)
+    }
+}
+
+
+extension WebViewController: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
+        if let url = navigationAction.request.url {
+            if AppAuthController.shared.isRedirectURI(url) {
+                decisionHandler(.cancel)
+                AppAuthController.shared.tryResumeAuthorizationFlow(with: url)
+                if let sceneDelegate = UIApplication.shared.connectedScenes
+                    .first(where: { $0.activationState == .foregroundActive })?.delegate as? SceneDelegate {
+                    sceneDelegate.userDidFinishAuthentication()
+                }
+                return
+            } else if url.absoluteString.contains("eduid.nl/login/") && isRegistrationFlow {
+                // Navigate from login to registration
+                decisionHandler(.cancel)
+                let previousUrl = url.absoluteString
+                let modifiedUrl = previousUrl.replacingOccurrences(of: "/login/", with: "/request/")
+                webView.load(URLRequest(url: URL(string: modifiedUrl)!))
+                return
+            }
+        }
+        decisionHandler(.allow)
+    }
+}

--- a/EduID/Services/AppAuthController.swift
+++ b/EduID/Services/AppAuthController.swift
@@ -152,8 +152,15 @@ public class AppAuthController: NSObject {
         return authState != nil
     }
     
-    public func authorize(viewController: UIViewController, completion: (() -> Void)? = nil) {
-        let externalUserAgent = OIDExternalUserAgentIOSSafari(presentingViewController: viewController)
+    public func authorize(
+        navigationController: UINavigationController,
+        isRegistrationFlow: Bool = false,
+        completion: (() -> Void)? = nil
+    ) {
+        let externalUserAgent = OIDExternalUserAgentUsingWebViewController(
+            navigationController: navigationController,
+            isRegistrationFlow: isRegistrationFlow
+        )
         currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request, externalUserAgent: externalUserAgent) {
             [weak self] authState, error in
             guard let self else { return }

--- a/EduID/Types/Notification.Name.swift
+++ b/EduID/Types/Notification.Name.swift
@@ -9,6 +9,7 @@ extension Notification.Name {
     public static let didUpdateEmail = Notification.Name("didUpdateEmail")
     public static let willAddPassword = Notification.Name("willAddPassword")
     public static let willChangePassword = Notification.Name("willChangePassword")
+    public static let onMagicLinkOpened = Notification.Name("magicLinkOpened")
     public static let firstTimeAuthorizationComplete = Notification.Name(rawValue: "firstTimeAuthorizationComplete")
     public static let firstTimeAuthorizationCompleteWithSecretPresent = Notification.Name(rawValue: "firstTimeAuthorizationCompleteWithSecretPresent")
     

--- a/EduID/Types/ScreenType.swift
+++ b/EduID/Types/ScreenType.swift
@@ -65,6 +65,8 @@ enum ScreenType: Int, CaseIterable {
     case pincodeScreen
     case oneTimeCodeScreen
     
+    case webView
+    
     case none
     
     func nextCreateEduIDScreen() -> ScreenType {
@@ -181,7 +183,7 @@ enum ScreenType: Int, CaseIterable {
             addLogoTo(item: item)
             item.hidesBackButton = true
             
-            // Back button
+            // Back button with logo
         default:
             addLogoTo(item: item)
             item.hidesBackButton = true

--- a/EduID/Utilities/Constants.swift
+++ b/EduID/Utilities/Constants.swift
@@ -40,6 +40,7 @@ enum Constants {
         static let passwordChangeUrl = "passwordChangeUrl"
         static let linkedAccountEmail = "linkedAccountEmail"
         static let linkedAccountInstitution = "linkedAccountInstitution"
+        static let magicLinkUrl = "magicLinkUrl"
     }
     
     enum RegistrationCheck {

--- a/eduID.xcodeproj/project.pbxproj
+++ b/eduID.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 		4F958BD92A39C24600DD0779 /* MyAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F958BD82A39C24600DD0779 /* MyAccountViewController.swift */; };
 		4F958BDC2A3A00C900DD0779 /* DeleteAccountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F958BDB2A3A00C900DD0779 /* DeleteAccountViewModel.swift */; };
 		4F958BDE2A3A00DF00DD0779 /* DeleteAccountViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F958BDD2A3A00DF00DD0779 /* DeleteAccountViewController.swift */; };
+		4F98B4562CF8BA1A0031DB49 /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F98B4552CF8BA180031DB49 /* WebViewController.swift */; };
 		4F9D272F2A33353F00F5A6ED /* localizations.yaml in Resources */ = {isa = PBXBuildFile; fileRef = 4F9D272E2A33353F00F5A6ED /* localizations.yaml */; };
 		4F9D27312A33395C00F5A6ED /* Localizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9D27302A33395C00F5A6ED /* Localizable.swift */; };
 		4F9D27332A333A1B00F5A6ED /* String+Localicious.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F9D27322A333A1B00F5A6ED /* String+Localicious.swift */; };
@@ -726,6 +727,7 @@
 		4F958BD82A39C24600DD0779 /* MyAccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAccountViewController.swift; sourceTree = "<group>"; };
 		4F958BDB2A3A00C900DD0779 /* DeleteAccountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountViewModel.swift; sourceTree = "<group>"; };
 		4F958BDD2A3A00DF00DD0779 /* DeleteAccountViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountViewController.swift; sourceTree = "<group>"; };
+		4F98B4552CF8BA180031DB49 /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
 		4F9D272E2A33353F00F5A6ED /* localizations.yaml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.yaml; path = localizations.yaml; sourceTree = "<group>"; };
 		4F9D27302A33395C00F5A6ED /* Localizable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Localizable.swift; sourceTree = "<group>"; };
 		4F9D27322A333A1B00F5A6ED /* String+Localicious.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localicious.swift"; sourceTree = "<group>"; };
@@ -1502,6 +1504,14 @@
 			path = DeleteAccount;
 			sourceTree = "<group>";
 		};
+		4F98B4572CF8BA200031DB49 /* WebView */ = {
+			isa = PBXGroup;
+			children = (
+				4F98B4552CF8BA180031DB49 /* WebViewController.swift */,
+			);
+			path = WebView;
+			sourceTree = "<group>";
+		};
 		4FA824642B06476600B0D802 /* DeleteKeyConfirmation */ = {
 			isa = PBXGroup;
 			children = (
@@ -1577,6 +1587,7 @@
 		4FF567582A31D32E00616341 /* Flows */ = {
 			isa = PBXGroup;
 			children = (
+				4F98B4572CF8BA200031DB49 /* WebView */,
 				4F83FB0C2A4DB4F200C2930E /* EnvironmentSwitcher */,
 				7364BAC82A389AD6003FB978 /* VerifyAuthentication */,
 				73DD92302A334FCC0065956E /* VerifyPinCode */,
@@ -2119,6 +2130,7 @@
 				4FF567BF2A31D32E00616341 /* VerifyScanResultViewController.swift in Sources */,
 				4FF567D82A31D32E00616341 /* CreateEduIDCoordinator.swift in Sources */,
 				4F93D47D2BC7E5C600D92A53 /* VerifiedInformationControlCollapsible.swift in Sources */,
+				4F98B4562CF8BA1A0031DB49 /* WebViewController.swift in Sources */,
 				4FF567C32A31D32E00616341 /* CreateEduIDEnterPersonalInfoViewModel.swift in Sources */,
 				4F958BD92A39C24600DD0779 /* MyAccountViewController.swift in Sources */,
 				4F909EA82A31CDDC00FC1506 /* NSAttributedString+Styling.swift in Sources */,

--- a/eduID/SceneDelegate.swift
+++ b/eduID/SceneDelegate.swift
@@ -71,11 +71,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         } else if (url.absoluteString.range(of: "created") != nil) {
             accountWasJustCreated = true
             NotificationCenter.default.post(name: .createEduIDDidReturnFromMagicLink, object: nil)
+        } else if (url.absoluteString.range(of: "saml/guest-idp/magic") != nil) {
+            // Email verification URI
+            NotificationCenter.default.post(name: .onMagicLinkOpened, object: nil, userInfo: [Constants.UserInfoKey.magicLinkUrl: url])
         } else if AppAuthController.shared.isRedirectURI(url) {
             AppAuthController.shared.tryResumeAuthorizationFlow(with: url)
-            if accountWasJustCreated == nil {
-                getAppropriateLaunchOption()
-            }
+            userDidFinishAuthentication()
             return
         } else if (url.absoluteString.range(of: "external-account-linked-error") != nil) {
             NotificationCenter.default.post(name: .externalAccountLinkError, object: nil)
@@ -95,6 +96,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 object: nil,
                 userInfo: [Constants.UserInfoKey.linkedAccountEmail: linkedAccountEmail]
             )
+        }
+    }
+    
+    public func userDidFinishAuthentication() {
+        if accountWasJustCreated == nil {
+            getAppropriateLaunchOption()
         }
     }
     


### PR DESCRIPTION
This PR changes the login flow so that it does not open Safari anymore, but the user stays inside the app, in a special view controller, containing a WKWebView.
We also intercept the link to the email verification, and load that inside the same browser, so that the flow resumes inside the same session.
Once the login / registration flow completes, it will continue in the app with the same screens as before.
This is implemented to fulfill the requirement made by Apple that the user does not leave the app, reducing the experience.