### PR TITLE
TIQR-485: Fix registration flow

### DIFF
--- a/EduID/Flows/WebView/WebViewController.swift
+++ b/EduID/Flows/WebView/WebViewController.swift
@@ -14,6 +14,7 @@ class WebViewController: BaseViewController {
     var isRegistrationFlow = false
     
     private var webView: WKWebView!
+    private var dontInterceptNextNavigation = false
     
     required init(startURL: URL) {
         self.startURL = startURL
@@ -46,6 +47,7 @@ class WebViewController: BaseViewController {
             return
         }
         // Navigate to the URL in our browser
+        dontInterceptNextNavigation = true
         self.webView.load(URLRequest(url: url))
     }
     
@@ -67,6 +69,11 @@ class WebViewController: BaseViewController {
 extension WebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void) {
         if let url = navigationAction.request.url {
+            if dontInterceptNextNavigation {
+                dontInterceptNextNavigation = false
+                decisionHandler(.allow)
+                return
+            }
             if AppAuthController.shared.isRedirectURI(url) {
                 decisionHandler(.cancel)
                 AppAuthController.shared.tryResumeAuthorizationFlow(with: url)

--- a/eduID/SceneDelegate.swift
+++ b/eduID/SceneDelegate.swift
@@ -61,7 +61,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        handleURLFromRedirect(url: URLContexts.first?.url)
+        _ = handleURLFromRedirect(url: URLContexts.first?.url)
     }
     
     func handleURLFromRedirect(url: URL?) -> Bool {
@@ -76,7 +76,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         } else if (url.absoluteString.range(of: "saml/guest-idp/magic") != nil) {
             // Email verification URI
             NotificationCenter.default.post(name: .onMagicLinkOpened, object: nil, userInfo: [Constants.UserInfoKey.magicLinkUrl: url])
-            return true
+            return false
         } else if AppAuthController.shared.isRedirectURI(url) {
             AppAuthController.shared.tryResumeAuthorizationFlow(with: url)
             userDidFinishAuthentication()


### PR DESCRIPTION
The registration flow ended in a magic link URL, but when we don't come from the mail client, it was ending the flow too early. Now we allow the magic link to forward us to the next link, where we get our tokens.