### PR TITLE
TIQR-504: Show error data from the API if registration fails

### DIFF
--- a/EduID/Flows/CreateEduID/ViewControllers/CreatePincodeSecondEntryViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreatePincodeSecondEntryViewController.swift
@@ -17,8 +17,8 @@ class CreatePincodeSecondEntryViewController: PincodeBaseViewController {
         createPincodeViewModel.showErrorDialogClosure = { [weak self] error in
             guard let self = self else { return }
             let alert = UIAlertController(
-                title: L.Generic.RequestError.Title.localization,
-                message: error.localizedFromApi,
+                title: error.title,
+                message: error.message,
                 preferredStyle: .alert)
             alert.addAction(.init(title: L.Generic.RequestError.CloseButton.localization, style: .cancel) { _ in
                 alert.dismiss(animated: true)

--- a/EduID/Flows/CreateEduID/ViewModels/CreatePincodeAndBiometricAccessViewModel.swift
+++ b/EduID/Flows/CreateEduID/ViewModels/CreatePincodeAndBiometricAccessViewModel.swift
@@ -23,7 +23,7 @@ final class CreatePincodeAndBiometricAccessViewModel: NSObject {
     var showPromptUseBiometricAccessClosure: (() -> Void)?
     var biometricAccessSuccessClosure: (() -> Void)?
     var biometricAccessFailureClosure: ((Error) -> Void)?
-    var showErrorDialogClosure: ((Error) -> Void)?
+    var showErrorDialogClosure: ((EduIdError) -> Void)?
     
     var nextScreenDelegate: ShowNextScreenDelegate?
     private let biometricService = BiometricService()
@@ -41,7 +41,7 @@ final class CreatePincodeAndBiometricAccessViewModel: NSObject {
                 await requestTiqrEnroll() { [weak self] error in
                     guard let self else { return }
                     if let error {
-                        self.showErrorDialogClosure?(error)
+                        self.showErrorDialogClosure?(EduIdError.from(error))
                     } else {
                         self.showUseBiometricScreenClosure?()
                     }


### PR DESCRIPTION
We try to parse the error sent from the server so that we can send a more precise dialog with the cause for the user.