### PR TITLE
TIQR-523: Create eduID in native flow

### DIFF
--- a/EduID/Flows/CreateEduID/ViewControllers/CheckEmailViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CheckEmailViewController.swift
@@ -71,7 +71,7 @@ class CheckEmailViewController: CreateEduIDBaseViewController {
          }
     }
 
-        @objc func dismissInfoScreen() {
+    @objc func dismissInfoScreen() {
         if let navigationController = navigationController {
             navigationController.dismiss(animated: true)
         } else {

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDCreatedViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDCreatedViewController.swift
@@ -63,8 +63,9 @@ class CreateEduIDCreatedViewController: CreateEduIDBaseViewController {
             assertionFailure("Navigation controller could not be found!")
             return
         }
-        AppAuthController.shared.authorize(navigationController: navigationController)
-        showNextScreen()
+        AppAuthController.shared.authorize(navigationController: navigationController) { [weak self] in
+            self?.showNextScreen()
+        }
     }
 
 }

--- a/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDLandingPageViewController.swift
+++ b/EduID/Flows/CreateEduID/ViewControllers/CreateEduIDLandingPageViewController.swift
@@ -52,7 +52,7 @@ class CreateEduIDLandingPageViewController: CreateEduIDBaseViewController {
         scanQRButton.addTarget(self, action: #selector(showScanScreen), for: .touchUpInside)
         
         //the action for this button is on CreateEduIDBaseViewController superclass
-        noEduIDYetButton.addTarget(self, action: #selector(noEduIdTapped), for: .touchUpInside)
+        noEduIDYetButton.addTarget(self, action: #selector(showNextScreen), for: .touchUpInside)
         
         // - create the stackview
         stack = AnimatedVStackView(arrangedSubviews: [logo, posterLabel, imageView, lowerSpaceView, signInButton, scanQRButton])
@@ -99,14 +99,6 @@ class CreateEduIDLandingPageViewController: CreateEduIDBaseViewController {
             assertionFailure("Navigation controller could not be found!")
             return
         }
-        AppAuthController.shared.authorize(navigationController: navigationController, isRegistrationFlow: false)
-    }
-    
-    @objc func noEduIdTapped() {
-        guard let navigationController else {
-            assertionFailure("Navigation controller could not be found!")
-            return
-        }
-        AppAuthController.shared.authorize(navigationController: navigationController, isRegistrationFlow: true)
+        AppAuthController.shared.authorize(navigationController: navigationController)
     }
 }

--- a/EduID/Flows/PersonalInfo/PersonalInfoCoordinator.swift
+++ b/EduID/Flows/PersonalInfo/PersonalInfoCoordinator.swift
@@ -171,10 +171,8 @@ extension PersonalInfoCoordinator: AccountLinkingErrorDelegate {
     
     func openInWebView(_ url: URL) {
         guard let navigationController else { return }
-        let webViewController = WebViewController(startURL: url)
+        let webViewController = WebViewController(startURL: url, registrationURL: nil)
         webViewController.modalPresentationStyle = .pageSheet
-        webViewController.isRegistrationFlow = false
-        webViewController.webViewControllerDelegate = self
         if #available(iOS 15.0, *),
            let sheet = navigationController.sheetPresentationController {
             sheet.detents = [.large()]

--- a/EduID/Flows/WebView/WebViewController.swift
+++ b/EduID/Flows/WebView/WebViewController.swift
@@ -15,14 +15,15 @@ protocol WebViewControllerDelegate: AnyObject {
 class WebViewController: BaseViewController {
     
     var startURL: URL!
-    var isRegistrationFlow = false
+    var registrationURL: URL?
     
     private var webView: WKWebView!
     private var dontInterceptNextNavigation = false
     weak var webViewControllerDelegate: WebViewControllerDelegate?
     
-    required init(startURL: URL) {
+    required init(startURL: URL, registrationURL: URL?) {
         self.startURL = startURL
+        self.registrationURL = registrationURL
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -39,7 +40,12 @@ class WebViewController: BaseViewController {
         webView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(webView)
         webView.edgesToSuperview(usingSafeArea: true)
-        webView.load(URLRequest(url: startURL))
+        if registrationURL != nil {
+            webView.load(URLRequest(url: registrationURL!))
+            dontInterceptNextNavigation = true
+        } else {
+            webView.load(URLRequest(url: startURL))
+        }
         webView.navigationDelegate = self
         
         NotificationCenter.default.addObserver(self, selector: #selector(onMagicLinkOpened), name: .onMagicLinkOpened, object: nil)
@@ -87,13 +93,6 @@ extension WebViewController: WKNavigationDelegate {
                     sceneDelegate.userDidFinishAuthentication()
                 }
                 return
-            } else if url.absoluteString.contains("eduid.nl/login/") && isRegistrationFlow {
-                // Navigate from login to registration
-                decisionHandler(.cancel)
-                let previousUrl = url.absoluteString
-                let modifiedUrl = previousUrl.replacingOccurrences(of: "/login/", with: "/request/")
-                webView.load(URLRequest(url: URL(string: modifiedUrl)!))
-                return
             } else {
                 guard let scenedelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else {
                     return
@@ -106,8 +105,15 @@ extension WebViewController: WKNavigationDelegate {
                     return
                 }
                 if isAppHost(url) && scenedelegate.handleURLFromRedirect(url: url) {
-                    decisionHandler(.cancel)
-                    dismissInfoScreen()
+                    if registrationURL != nil {
+                        // Continue with the original auth flow
+                        decisionHandler(.cancel)
+                        webView.load(URLRequest(url: startURL))
+                        registrationURL = nil
+                    } else {
+                        decisionHandler(.cancel)
+                        dismissInfoScreen()
+                    }
                     return
                 }
             }

--- a/EduID/Services/AppAuthController.swift
+++ b/EduID/Services/AppAuthController.swift
@@ -11,6 +11,7 @@ public class AppAuthController: NSObject {
     private var currentAuthorizationFlow: OIDExternalUserAgentSession?
     private var authState: OIDAuthState? {
         didSet {
+            BearerTokenHandler.setAccessTokenOnHeaders(accessToken: authState?.lastTokenResponse?.accessToken)
             if let state = authState {
                 _ = OIDTokenStorage
                     .storeAuthState(state, forService: authConfig.clientId)
@@ -61,6 +62,7 @@ public class AppAuthController: NSObject {
             authConfig.clientId
         }
     }
+    var registrationUrl: URL?
     
     //MARK: - init
     private override init() {
@@ -154,13 +156,13 @@ public class AppAuthController: NSObject {
     
     public func authorize(
         navigationController: UINavigationController,
-        isRegistrationFlow: Bool = false,
         completion: (() -> Void)? = nil
     ) {
         let externalUserAgent = OIDExternalUserAgentUsingWebViewController(
             navigationController: navigationController,
-            isRegistrationFlow: isRegistrationFlow
+            registrationURL: registrationUrl
         )
+        registrationUrl = nil
         currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request, externalUserAgent: externalUserAgent) {
             [weak self] authState, error in
             guard let self else { return }
@@ -192,7 +194,7 @@ public class AppAuthController: NSObject {
 
     /// Ends user session by clearing the auth state
     public func clearAuthState() {
-       self.authState = nil
+        self.authState = nil
    }
     
 }

--- a/EduID/Services/BearerTokenHandler.swift
+++ b/EduID/Services/BearerTokenHandler.swift
@@ -41,13 +41,17 @@ class BearerDecodableRequestBuilder<T: Decodable>: URLSessionDecodableRequestBui
 
 class BearerTokenHandler {
     
+    static func setAccessTokenOnHeaders(accessToken: String?) {
+        if let accessToken {
+            OpenAPIClientAPI.customHeaders[Constants.Headers.authorization] = "Bearer \(accessToken)"
+        } else {
+            OpenAPIClientAPI.customHeaders[Constants.Headers.authorization] = ""
+        }
+    }
+    
     static func performWithFreshTokens(completionHandler: @escaping () -> Void) {
         AppAuthController.shared.performWithFreshTokens { accessToken in
-            if let accessToken = accessToken {
-                OpenAPIClientAPI.customHeaders[Constants.Headers.authorization] = "Bearer \(accessToken)"
-            } else {
-                OpenAPIClientAPI.customHeaders[Constants.Headers.authorization] = ""
-            }
+            setAccessTokenOnHeaders(accessToken: accessToken)
             completionHandler()
         }
     }

--- a/EduID/Services/OIDExternalUserAgentIOSSafari.swift
+++ b/EduID/Services/OIDExternalUserAgentIOSSafari.swift
@@ -3,7 +3,7 @@ import AppAuth
 
 class OIDExternalUserAgentUsingWebViewController: NSObject {
     var _navigationController: UINavigationController!
-    var _isRegistrationFlow: Bool = false
+    var _registrationURL: URL? = nil
     var _externalUserAgentFlowInProgress: Bool = false
     weak var _session: OIDExternalUserAgentSession?
 
@@ -22,11 +22,11 @@ class OIDExternalUserAgentUsingWebViewController: NSObject {
      */
     required init(
         navigationController: UINavigationController,
-        isRegistrationFlow: Bool
+        registrationURL: URL?
     ) {
         super.init()
         self._navigationController = navigationController
-        self._isRegistrationFlow = isRegistrationFlow
+        self._registrationURL = registrationURL
     }
 
     func cleanUp() {
@@ -47,9 +47,8 @@ extension OIDExternalUserAgentUsingWebViewController: OIDExternalUserAgent {
 
         
         if let requestURL = request.externalUserAgentRequestURL() {
-            let webViewController = WebViewController(startURL: requestURL)
+            let webViewController = WebViewController(startURL: requestURL, registrationURL: _registrationURL)
             webViewController.modalPresentationStyle = .pageSheet
-            webViewController.isRegistrationFlow = _isRegistrationFlow
             if #available(iOS 15.0, *),
                let sheet = _navigationController.sheetPresentationController {
                 sheet.detents = [.large()]

--- a/EduID/Types/Notification.Name.swift
+++ b/EduID/Types/Notification.Name.swift
@@ -3,6 +3,7 @@ import Foundation
 extension Notification.Name {
     
     public static let createEduIDDidReturnFromMagicLink = Notification.Name("createEduIDDidReturnFromMagicLink")
+    public static let createEduIDUserCreateEmailOpened = Notification.Name("createEduIDUserCreateEmailOpened")
     public static let didAddLinkedAccounts = Notification.Name("didAddLinkedAccounts")
     public static let accountAlreadyLinked = Notification.Name("accountAlreadyLinked")
     public static let externalAccountLinkError = Notification.Name("externalAccountLinkError")

--- a/eduID/SceneDelegate.swift
+++ b/eduID/SceneDelegate.swift
@@ -71,12 +71,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             return true
         } else if (url.absoluteString.range(of: "created") != nil) {
             accountWasJustCreated = true
-            NotificationCenter.default.post(name: .createEduIDDidReturnFromMagicLink, object: nil)
             return true
         } else if (url.absoluteString.range(of: "saml/guest-idp/magic") != nil) {
             // Email verification URI
             NotificationCenter.default.post(name: .onMagicLinkOpened, object: nil, userInfo: [Constants.UserInfoKey.magicLinkUrl: url])
             return false
+        } else if (url.absoluteString.range(of: "api/create-from-mobile-api/in-app") != nil) {
+            accountWasJustCreated = true
+            AppAuthController.shared.registrationUrl = url
+            NotificationCenter.default.post(name: .createEduIDDidReturnFromMagicLink, object: nil)
+            return true
         } else if AppAuthController.shared.isRedirectURI(url) {
             AppAuthController.shared.tryResumeAuthorizationFlow(with: url)
             userDidFinishAuthentication()


### PR DESCRIPTION
This PR adds back the native registration flow (instead of starting registration in the browser).
For this we need to deeplink to the app from the email we receive when registering.
There's also a URL swap when starting the authorization, because we first need to verify the device before continuing with authorization.
During the implementation I found an issue that the OpenAPI custom headers are not updated immediately when the token changes, so I fixed that as well.