### PR TITLE
TIQR-494: Push notification improvements

### DIFF
--- a/EduID/Flows/Home/MainCoordinator.swift
+++ b/EduID/Flows/Home/MainCoordinator.swift
@@ -63,6 +63,15 @@ extension MainCoordinator: HomeViewControllerDelegate  {
     }
     
     func homeViewControllerShowAuthenticationScreen(with payload: String) {
+        // If there are any screens already open, close them
+        children.removeAll()
+        if homeNavigationController.presentedViewController != nil {
+            homeNavigationController.dismiss(animated: true) { [weak self] in
+                self?.homeNavigationController.popToRootViewController(animated: true)
+            }
+        } else {
+            homeNavigationController.popToRootViewController(animated: true)
+        }
         let verifyAuthenticationCoordinator = VerifyAuthenticationCoordinator(viewControllerToPresentOn: homeNavigationController)
         verifyAuthenticationCoordinator.delegate = self
         children.append(verifyAuthenticationCoordinator)

--- a/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
+++ b/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
@@ -1,5 +1,6 @@
 import UIKit
 import TiqrCoreObjC
+import Tiqr
 
 protocol VerifyAuthenticationDelegate: AnyObject {
     func verifyAuthenticationCoordinatorDismissActivityFlow(coordinator: CoordinatorType)
@@ -21,6 +22,10 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
     func start(with payload: String) {
         self.payload = payload
         authenticate()
+        // Next to that, we also clear the recent notifications cache, making sure this screen is not triggered twice
+        // (by getting it, we also clear it)
+        let appGroup = Bundle.main.object(forInfoDictionaryKey: "TiqrAppGroup") as! String
+        _ = RecentNotifications(appGroup: appGroup).getLastNotificationChallenge()
     }
     
     private func authenticate() {


### PR DESCRIPTION
* When you are in the app, on another screen than Home, it will now close that screen and open the authentication screen when a push notification arrives
* There was an edge case that if you were already in the app, and logged in via a push notification, it would ask you again to authenticate using the old challenge. This is fixed now.