### PR TITLE
TIQR-604: Show service name from notification

### DIFF
--- a/EduID/Flows/Home/HomeViewController.swift
+++ b/EduID/Flows/Home/HomeViewController.swift
@@ -210,7 +210,10 @@ class HomeViewController: UIViewController, ScreenWithScreenType {
     @objc private func loadViewWhenReceivingNotification(_ notification: Notification) {
         if let notificationObject = notification.userInfo?[Constants.UserInfoKey.tiqrAuthObject] as? String,
            !notificationObject.isEmpty {
-            delegate?.homeViewControllerShowAuthenticationScreen(with: notificationObject)
+            delegate?.homeViewControllerShowAuthenticationScreen(
+                payload: notificationObject,
+                serviceName: notification.userInfo?[Constants.UserInfoKey.notificationServiceName] as? String
+            )
         } else if AppAuthController.shared.isLoggedIn() {
             openPendingScreen(animated: self.screenRefreshWasRequested)
         } else if AppAuthController.shared.hasPendingAuthFlow {

--- a/EduID/Flows/Home/HomeViewControllerDelegate.swift
+++ b/EduID/Flows/Home/HomeViewControllerDelegate.swift
@@ -6,5 +6,5 @@ protocol HomeViewControllerDelegate: AnyObject {
     func homeViewControllerShowSecurityScreen(viewController: HomeViewController, animated: Bool)
     func homeViewControllerShowActivityScreen(viewController: HomeViewController, animated: Bool)
     func homeViewControllerShowScanScreen(viewController: HomeViewController)
-    func homeViewControllerShowAuthenticationScreen(with payload: String)
+    func homeViewControllerShowAuthenticationScreen(payload: String, serviceName: String?)
 }

--- a/EduID/Flows/Home/MainCoordinator.swift
+++ b/EduID/Flows/Home/MainCoordinator.swift
@@ -62,7 +62,7 @@ extension MainCoordinator: HomeViewControllerDelegate  {
         scanCoordinator.start()
     }
     
-    func homeViewControllerShowAuthenticationScreen(with payload: String) {
+    func homeViewControllerShowAuthenticationScreen(payload: String, serviceName: String?) {
         // If there are any screens already open, close them
         children.removeAll()
         if homeNavigationController.presentedViewController != nil {
@@ -75,7 +75,7 @@ extension MainCoordinator: HomeViewControllerDelegate  {
         let verifyAuthenticationCoordinator = VerifyAuthenticationCoordinator(viewControllerToPresentOn: homeNavigationController)
         verifyAuthenticationCoordinator.delegate = self
         children.append(verifyAuthenticationCoordinator)
-        verifyAuthenticationCoordinator.start(with: payload)
+        verifyAuthenticationCoordinator.start(payload: payload, serviceName: serviceName)
     }
 
 }

--- a/EduID/Flows/Scanning/VerifyScanResultViewController.swift
+++ b/EduID/Flows/Scanning/VerifyScanResultViewController.swift
@@ -67,13 +67,13 @@ class VerifyScanResultViewController: BaseViewController {
         case .enrollment:
             let challenge = viewModel.challenge as? EnrollmentChallenge
             middlePosterLabel = requestLoginLabel(
-                entityName: challenge?.identityProviderDisplayName ?? challenge?.identityDisplayName ?? "",
+                entityName: viewModel.serviceName ?? challenge?.identityProviderDisplayName ?? challenge?.identityDisplayName ?? "",
                 challengeType: viewModel.challengeType ?? .invalid
             )
         case .authentication:
             let challenge = viewModel.challenge as? AuthenticationChallenge
             middlePosterLabel = requestLoginLabel(
-                entityName: challenge?.serviceProviderDisplayName ?? challenge?.serviceProviderIdentifier ?? "",
+                entityName: viewModel.serviceName ?? challenge?.serviceProviderDisplayName ?? challenge?.serviceProviderIdentifier ?? "",
                 challengeType: viewModel.challengeType ?? .invalid
             )
         default:

--- a/EduID/Flows/Scanning/ViewModels/ScanViewModel.swift
+++ b/EduID/Flows/Scanning/ViewModels/ScanViewModel.swift
@@ -13,6 +13,7 @@ final class ScanViewModel: NSObject {
     
     // - challenge object and type
     var challenge: NSObject?
+    var serviceName: String?
     var challengeType: TIQRChallengeType?
     
     let frameSize: CGFloat = 275

--- a/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
+++ b/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
@@ -11,7 +11,7 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
     var viewControllerToPresentOn: UIViewController?
     weak var delegate: VerifyAuthenticationDelegate?
     private var payload: String?
-    var challenge: NSObject?
+    private var serviceName: String?
     var challengeType: TIQRChallengeType?
     private var dismissVerifyAuthentication: (() -> Void)?
     
@@ -19,13 +19,14 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
         self.viewControllerToPresentOn = viewControllerToPresentOn
     }
     
-    func start(with payload: String) {
+    func start(payload: String, serviceName: String?) {
         self.payload = payload
+        self.serviceName = serviceName
         authenticate()
         // Next to that, we also clear the recent notifications cache, making sure this screen is not triggered twice
         // (by getting it, we also clear it)
         let appGroup = Bundle.main.object(forInfoDictionaryKey: "TiqrAppGroup") as! String
-        _ = RecentNotifications(appGroup: appGroup).getLastNotificationChallenge()
+        _ = RecentNotifications(appGroup: appGroup).getLastNotificationData()
     }
     
     private func authenticate() {
@@ -38,6 +39,7 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
                 case .enrollment, .authentication:
                     let viewModel = ScanViewModel()
                     viewModel.challenge = challengeObject
+                    viewModel.serviceName = serviceName
                     viewModel.challengeType = type
                     self.handleAuthenticationResult(with: viewModel)
                 case .invalid:

--- a/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
+++ b/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
@@ -39,7 +39,7 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
                 case .enrollment, .authentication:
                     let viewModel = ScanViewModel()
                     viewModel.challenge = challengeObject
-                    viewModel.serviceName = serviceName
+                    viewModel.serviceName = self.serviceName
                     viewModel.challengeType = type
                     self.handleAuthenticationResult(with: viewModel)
                 case .invalid:

--- a/EduID/Utilities/Constants.swift
+++ b/EduID/Utilities/Constants.swift
@@ -36,6 +36,7 @@ enum Constants {
     
     enum UserInfoKey {
         static let tiqrAuthObject = "tiqrAuthenticationObject"
+        static let notificationServiceName = "notificationServiceName"
         static let emailUpdateUrl = "emailUpdateUrl"
         static let passwordChangeUrl = "passwordChangeUrl"
         static let linkedAccountEmail = "linkedAccountEmail"

--- a/Notifications/NotificationService.swift
+++ b/Notifications/NotificationService.swift
@@ -26,9 +26,11 @@ class NotificationService: UNNotificationServiceExtension {
         let payload = bestAttemptContent?.userInfo
         let challenge = payload?["challenge"]
         let authenticationTimeout = payload?["authenticationTimeout"]
+        let serviceName = payload?["serviceName"] as? String
         RecentNotifications(appGroup: appGroup).onNewNotification(
             timeOut: authenticationTimeout,
             challenge: challenge,
+            serviceName: serviceName,
             notificationId: request.identifier
         )
         contentHandler(bestAttemptContent ?? UNMutableNotificationContent())

--- a/eduID.xcodeproj/project.pbxproj
+++ b/eduID.xcodeproj/project.pbxproj
@@ -2650,7 +2650,7 @@
 			repositoryURL = "https://github.com/Tiqr/tiqr-app-core-ios";
 			requirement = {
 				kind = revision;
-				revision = 13ea1e3beb02bca9ae8a5387f89e44d0ddcc3e8d;
+				revision = 9ca8f15a6fdf3cd22cfd3eb09b83b243059bdb30;
 			};
 		};
 		4FF567D92A31D3FA00616341 /* XCRemoteSwiftPackageReference "TinyConstraints" */ = {

--- a/eduID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/eduID.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9560b458c18da5e558984d16fcddc2ec42117266cdea0de2916c8c366059d5d0",
+  "originHash" : "c36610b4aff54900feaf77e5e32feabcd35fcce8dd6bdbd557ea877e330f906f",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -78,7 +78,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Tiqr/tiqr-app-core-ios",
       "state" : {
-        "revision" : "13ea1e3beb02bca9ae8a5387f89e44d0ddcc3e8d"
+        "revision" : "9ca8f15a6fdf3cd22cfd3eb09b83b243059bdb30"
       }
     }
   ],

--- a/eduID/AppDelegate.swift
+++ b/eduID/AppDelegate.swift
@@ -55,14 +55,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 }
             }
         }
-        if let challenge = RecentNotifications(appGroup: appGroup).getLastNotificationChallenge() {
+        if let data = RecentNotifications(appGroup: appGroup).getLastNotificationData() {
             // Home will listen to the notification, so we add a bit of delay to make sure it has been started.
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
                 guard let self else {
                     return
                 }
                 if !self.didHandleNotification {
-                    self.getNotificationObject(from: challenge)
+                    self.getNotificationObject(challenge: data.challenge, serviceName: data.serviceName)
                 }
                 // Reset back to default value
                 self.didHandleNotification = false
@@ -87,7 +87,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         //TIQR challenge
-        Tiqr.shared.startChallenge(challenge: url.absoluteString)
+        Tiqr.shared.startChallenge(challenge: url.absoluteString, serviceName: nil)
         
         //AppAuth redirect
         if AppAuthController.shared.isRedirectURI(url) {
@@ -115,7 +115,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             let userInfo = notification.request.content.userInfo
             if let challenge = userInfo["challenge"] as? String {
                 DispatchQueue.main.async { [weak self] in
-                    self?.getNotificationObject(from: challenge)
+                    self?.getNotificationObject(challenge: challenge, serviceName: userInfo["serviceName"] as? String)
                 }
             }
             completionHandler([])
@@ -128,13 +128,18 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         if let challenge = userInfo["challenge"] as? String {
             didHandleNotification = true
             DispatchQueue.main.async { [weak self] in
-                self?.getNotificationObject(from: challenge)
+                self?.getNotificationObject(challenge: challenge, serviceName: userInfo["serviceName"] as? String)
             }
         }
     }
     
-    private func getNotificationObject(from challenge: String) {
-        let notificationObject: [String: Any] = [Constants.UserInfoKey.tiqrAuthObject: challenge]
+    private func getNotificationObject(challenge: String, serviceName: String?) {
+        var notificationObject: [String: Any] = [
+            Constants.UserInfoKey.tiqrAuthObject: challenge,
+        ]
+        if let serviceName {
+            notificationObject[Constants.UserInfoKey.notificationServiceName] = serviceName
+        }
         NotificationCenter.default.post(name: .firstTimeAuthorizationCompleteWithSecretPresent,
                                         object: nil, userInfo: notificationObject)
     }
@@ -144,8 +149,8 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
     
     func applicationDidBecomeActive(_ application: UIApplication) {
-        if let challenge = RecentNotifications(appGroup: appGroup).getLastNotificationChallenge() {
-            self.getNotificationObject(from: challenge)
+        if let data = RecentNotifications(appGroup: appGroup).getLastNotificationData() {
+            self.getNotificationObject(challenge: data.challenge, serviceName: data.serviceName)
         }
     }
 }

--- a/eduID/AppDelegate.swift
+++ b/eduID/AppDelegate.swift
@@ -129,11 +129,9 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             didHandleNotification = true
             DispatchQueue.main.async { [weak self] in
                 self?.getNotificationObject(challenge: challenge, serviceName: userInfo["serviceName"] as? String)
-                completionHandler()
             }
-        } else {
-            completionHandler()
         }
+        completionHandler()
     }
     
     private func getNotificationObject(challenge: String, serviceName: String?) {

--- a/eduID/AppDelegate.swift
+++ b/eduID/AppDelegate.swift
@@ -129,7 +129,10 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
             didHandleNotification = true
             DispatchQueue.main.async { [weak self] in
                 self?.getNotificationObject(challenge: challenge, serviceName: userInfo["serviceName"] as? String)
+                completionHandler()
             }
+        } else {
+            completionHandler()
         }
     }
     

--- a/eduID/SceneDelegate.swift
+++ b/eduID/SceneDelegate.swift
@@ -138,11 +138,19 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
             return
         }
-        if let challenge = RecentNotifications(appGroup: appGroup).getLastNotificationChallenge(),
+        if let data = RecentNotifications(appGroup: appGroup).getLastNotificationData(),
            !appDelegate.didHandleNotification {
-            let notificationObject: [String: Any] = [Constants.UserInfoKey.tiqrAuthObject: challenge]
-            NotificationCenter.default.post(name: .firstTimeAuthorizationCompleteWithSecretPresent,
-                                            object: nil, userInfo: notificationObject)
+            var notificationObject: [String: Any] = [
+                Constants.UserInfoKey.tiqrAuthObject: data.challenge
+            ]
+            if let servicename = data.serviceName {
+                notificationObject[Constants.UserInfoKey.notificationServiceName] = data.serviceName
+            }
+            NotificationCenter.default.post(
+                name: .firstTimeAuthorizationCompleteWithSecretPresent,
+                object: nil,
+                userInfo: notificationObject
+            )
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             appDelegate.didHandleNotification = false

--- a/eduID/SceneDelegate.swift
+++ b/eduID/SceneDelegate.swift
@@ -143,8 +143,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             var notificationObject: [String: Any] = [
                 Constants.UserInfoKey.tiqrAuthObject: data.challenge
             ]
-            if let servicename = data.serviceName {
-                notificationObject[Constants.UserInfoKey.notificationServiceName] = data.serviceName
+            if let serviceName = data.serviceName {
+                notificationObject[Constants.UserInfoKey.notificationServiceName] = serviceName
             }
             NotificationCenter.default.post(
                 name: .firstTimeAuthorizationCompleteWithSecretPresent,


### PR DESCRIPTION
When the notification contains a serviceName property, we will show that to the user instead of the server address.
This will make authentication requests more readable to the user.