### PR TITLE
TIQR-608: Handle authentication error from deeplink

### DIFF
--- a/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
+++ b/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
@@ -68,16 +68,16 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
         let title = rawTitle == "unknown_error" ? L.AuthenticationFailed.Title.localization : rawTitle
         let description = (error?.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? error?.localizedDescription ?? L.Generic.RequestError.Description(args: String(error?.code ?? 0)).localization
 
-        let alert = UIAlertController(
-            title: title,
-            message: description,
-            preferredStyle: .alert
-        )
-        
-        alert.addAction(UIAlertAction(title: L.Generic.RequestError.CloseButton.localization, style: .default) { _ in
-            alert.dismiss(animated: true)
-        })
         DispatchQueue.main.async { [weak self] in
+            let alert = UIAlertController(
+                title: title,
+                message: description,
+                preferredStyle: .alert
+            )
+            
+            alert.addAction(UIAlertAction(title: L.Generic.RequestError.CloseButton.localization, style: .default) { _ in
+                alert.dismiss(animated: true)
+            })
             self?.viewControllerToPresentOn?.present(alert, animated: true, completion: nil)
         }
     }

--- a/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
+++ b/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
@@ -64,10 +64,12 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
     }
     
     private func handleAuthenticationError(error: NSError?) {
-        let rawTitle = (error?.userInfo[NSLocalizedDescriptionKey] as? String) ?? error?.domain ?? L.Generic.RequestError.Title.localization
-        let title = rawTitle == "unknown_error" ? L.AuthenticationFailed.Title.localization : rawTitle
-        let description = (error?.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? error?.localizedDescription ?? L.Generic.RequestError.Description(args: String(error?.code ?? 0)).localization
-
+        var title = (error?.userInfo[NSLocalizedDescriptionKey] as? String) ?? error?.domain ?? L.Generic.RequestError.Title.localization
+        var description = (error?.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? error?.localizedDescription ?? L.Generic.RequestError.Description(args: String(error?.code ?? 0)).localization
+        if title == "unknown_error" {
+            title = L.ResponseErrors.AuthenticationFailedTitle.localization
+            description = L.ResponseErrors.AuthenticationFailedMessage.localization
+        }
         DispatchQueue.main.async { [weak self] in
             let alert = UIAlertController(
                 title: title,
@@ -75,8 +77,10 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
                 preferredStyle: .alert
             )
             
-            alert.addAction(UIAlertAction(title: L.Generic.RequestError.CloseButton.localization, style: .default) { _ in
+            alert.addAction(UIAlertAction(title: L.Generic.RequestError.CloseButton.localization, style: .default) { [weak self] _ in
+                guard let self = self else { return }
                 alert.dismiss(animated: true)
+                self.delegate?.verifyAuthenticationCoordinatorDismissActivityFlow(coordinator: self)
             })
             self?.viewControllerToPresentOn?.present(alert, animated: true, completion: nil)
         }

--- a/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
+++ b/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
@@ -64,7 +64,8 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
     }
     
     private func handleAuthenticationError(error: NSError?) {
-        let title = (error?.userInfo[NSLocalizedDescriptionKey] as? String) ?? error?.domain ?? L.Generic.RequestError.Title.localization
+        let rawTitle = (error?.userInfo[NSLocalizedDescriptionKey] as? String) ?? error?.domain ?? L.Generic.RequestError.Title.localization
+        let title = rawTitle == "unknown_error" ? L.AuthenticationFailed.Title.localization : rawTitle
         let description = (error?.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? error?.localizedDescription ?? L.Generic.RequestError.Description(args: String(error?.code ?? 0)).localization
 
         let alert = UIAlertController(

--- a/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
+++ b/EduID/Flows/VerifyAuthentication/VerifyAuthenticationCoordinator.swift
@@ -43,8 +43,12 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
                     viewModel.challengeType = type
                     self.handleAuthenticationResult(with: viewModel)
                 case .invalid:
+                    self.handleAuthenticationError(error: error as? NSError)
                     break
                 default:
+                    if let error {
+                        self.handleAuthenticationError(error: error as NSError)
+                    }
                     break
                 }
             }
@@ -57,5 +61,23 @@ class VerifyAuthenticationCoordinator: CoordinatorType {
             self.delegate?.verifyAuthenticationCoordinatorDismissActivityFlow(coordinator: self)
         }
         (viewControllerToPresentOn as? UINavigationController)?.pushViewController(viewController, animated: true)
+    }
+    
+    private func handleAuthenticationError(error: NSError?) {
+        let title = (error?.userInfo[NSLocalizedDescriptionKey] as? String) ?? error?.domain ?? L.Generic.RequestError.Title.localization
+        let description = (error?.userInfo[NSLocalizedFailureReasonErrorKey] as? String) ?? error?.localizedDescription ?? L.Generic.RequestError.Description(args: String(error?.code ?? 0)).localization
+
+        let alert = UIAlertController(
+            title: title,
+            message: description,
+            preferredStyle: .alert
+        )
+        
+        alert.addAction(UIAlertAction(title: L.Generic.RequestError.CloseButton.localization, style: .default) { _ in
+            alert.dismiss(animated: true)
+        })
+        DispatchQueue.main.async { [weak self] in
+            self?.viewControllerToPresentOn?.present(alert, animated: true, completion: nil)
+        }
     }
 }


### PR DESCRIPTION
The error case was not handled in the coordinator, so there was no user feedback if there was an issue during the deeplink authentication flow, like a missing user enrolment.
