### PR TITLE
TIQR-608: Correctly detect authentication and enrolment URLs

### DIFF
--- a/eduID/SceneDelegate.swift
+++ b/eduID/SceneDelegate.swift
@@ -30,6 +30,7 @@
 import UIKit
 import Tiqr
 import TiqrCore
+import TiqrCoreObjC
 import AppAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -66,7 +67,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func handleURLFromRedirect(url: URL?) -> Bool {
         guard let url = url else { return false }
-        if (url.absoluteString.range(of: "tiqrauth") != nil) {
+        if TiqrConfig.isValidAuthenticationURL(url.absoluteString) {
             getAppropriateLaunchOption(with: url.absoluteString)
             return true
         } else if (url.absoluteString.range(of: "created") != nil) {


### PR DESCRIPTION
We were testing if the URL contains any "tiqrauth" string, but this was weak and incorrect. I reuse the logic now from the library, so it works now with the eduidauth:// scheme.