### PR TITLE
Do not sync translations with myconext anymore

### DIFF
--- a/.github/sync-myconext.yml
+++ b/.github/sync-myconext.yml
@@ -1,4 +1,0 @@
-OpenConext/OpenConext-myconext:
-  - source: localizations.yaml
-    dest: localizations.yaml
-

--- a/.github/workflows/localicious.yaml
+++ b/.github/workflows/localicious.yaml
@@ -5,25 +5,6 @@ on:
     paths:
     - 'EduID/localizations.yaml'
 jobs:
-  sync-myconext:
-    runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.head_commit.message, '#AUTO#') }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@master
-      - name: Get token for myconext repo
-        uses: actions/create-github-app-token@v1
-        id: app-token-myconext
-        with:
-          app-id: ${{ secrets.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_PRIVATE_KEY }}
-          owner: OpenConext
-      - name: Create PR for new translation in Openconext-myconext
-        uses: BetaHuhn/repo-file-sync-action@v1
-        with:
-          GH_INSTALLATION_TOKEN: ${{ steps.app-token-myconext.outputs.token }}
-          COMMIT_PREFIX: "#AUTO#"
-          CONFIG_PATH: .github/sync-myconext.yml
   sync-eduid-app-android:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.head_commit.message, '#AUTO#') }}
@@ -73,5 +54,3 @@ jobs:
       with:
         commit_message: Automated update of Localizable.strings after updating localizations.yaml
         file_pattern: '**/Localizable.strings **/Localizable.swift'
-
-  


### PR DESCRIPTION
Stop the attempts to keep the web and mobile app translation-strings in sync. Only sync the iOS and Android App